### PR TITLE
Add Skulls in Logic Counter

### DIFF
--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -44,11 +44,13 @@ const Checks = () => {
       checked: 0,
       available: 0,
       remaining: 0,
+      skulls: 0,
     };
 
     _.forEach(_.values(locations), regionLocations => {
       countLocations(regionLocations, newCounter);
     });
+    newCounter.skulls = LogicHelper.countSkullsInLogic();
 
     return newCounter;
   }, [locations]);
@@ -178,6 +180,7 @@ const LocationsList = ({
         checked: 0,
         available: 0,
         remaining: 0,
+        skulls: 0,
       };
       countLocations(locationData, locationsCounter);
 
@@ -234,6 +237,10 @@ const Info = ({ locationsCounter }) => {
           <tr>
             <td>{locationsCounter.remaining}</td>
             <td>Remaining</td>
+          </tr>
+          <tr>
+            <td>{locationsCounter.skulls}</td>
+            <td>Skulls in Logic</td>
           </tr>
         </tbody>
       </table>

--- a/src/utils/locations.js
+++ b/src/utils/locations.js
@@ -11,6 +11,7 @@ class Locations {
     this.locations = new Map();
 
     this.dropLocations = {};
+    this.skullsLocations = [];
     this.events = {};
     this.exits = {};
 
@@ -241,6 +242,10 @@ class Locations {
               vanillaItem: vanillaItem,
             };
             _.set(this.locations, locationName, locationData);
+
+            if (_.isEqual(type, "GS Token")) {
+              this.skullsLocations.push(locationName);
+            }
           }
         });
       }

--- a/src/utils/logic-helper.js
+++ b/src/utils/logic-helper.js
@@ -86,6 +86,10 @@ class LogicHelper {
     }
   }
 
+  static countSkullsInLogic() {
+    return _.size(_.filter(Locations.skullsLocations, locationName => LogicHelper.isLocationAvailable(locationName)));
+  }
+
   static _initRenamedAttributes() {
     // source: World.py __init__()
 


### PR DESCRIPTION
This PR adds a counter to the UI, attached to the already-present locations counter, of the number of Gold Skulltula tokens that are currently in logic based on the items the user currently has.