### PR TITLE
Properly check for Skip Child Zelda

### DIFF
--- a/src/utils/locations.js
+++ b/src/utils/locations.js
@@ -89,7 +89,7 @@ class Locations {
 
     // Weird Egg
     else if (_.isEqual(location.vanillaItem, "Weird Egg")) {
-      if (LogicHelper.settings.skip_child_zelda) {
+      if (_.isEqual(LogicHelper.settings.shuffle_child_trade, "skip_child_zelda")) {
         return false;
       } else {
         return !_.isEqual(LogicHelper.settings.shuffle_child_trade, "vanilla");


### PR DESCRIPTION
Fixes a logic bug where HC Malon Egg would be considered a progress location despite `shuffle_child_trade` being set to `"skip_child_zelda"`.