### PR TITLE
Small patch

### DIFF
--- a/src/context/trackerContext.js
+++ b/src/context/trackerContext.js
@@ -38,7 +38,9 @@ function parseItems(items_list, counters) {
       case "2e7752ec3fbc4c03b68c5621f853cad3":
         items.Magic_Bean = 10;
         break;
-      // Skull_Mask: 1,
+      case "a54955e5bcfd4fcd921062b5e298b137":
+        items.Skull_Mask = 1;
+        break;
       // Spooky_Mask: 0,
       // Keaton_Mask: 0,
       // Bunny_Hood: 0,

--- a/src/data/default-items.json
+++ b/src/data/default-items.json
@@ -7,7 +7,7 @@
   "Bottle": 0,
   "Rutos_Letter": 0,
   "Magic_Bean": 0,
-  "Skull_Mask": 1,
+  "Skull_Mask": 0,
   "Spooky_Mask": 0,
   "Keaton_Mask": 0,
   "Bunny_Hood": 0,

--- a/src/data/dungeon-boss-shortcuts.json
+++ b/src/data/dungeon-boss-shortcuts.json
@@ -1,0 +1,10 @@
+[
+  "Deku Tree",
+  "Dodongos Cavern",
+  "Jabu Jabus Belly",
+  "Forest Temple",
+  "Fire Temple",
+  "Water Temple",
+  "Shadow Temple",
+  "Spirit Temple"
+]

--- a/src/layouts/hashfrog.json
+++ b/src/layouts/hashfrog.json
@@ -53,6 +53,7 @@
             "magic",
             "boots_iron",
             "boots_hover",
+            "scale",
             "gerudo_card",
             "trade_3",
             "trade_2"

--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -5,9 +5,10 @@ import { useChecks, useLocation } from "../context/trackerContext";
 import Locations from "../utils/locations";
 import LogicHelper from "../utils/logic-helper";
 
+import { useLayout } from "../context/layoutContext";
+import DUNGEON_SHORTCUTS from "../data/dungeon-boss-shortcuts.json";
 import DUNGEONS from "../data/dungeons.json";
 import HINT_REGIONS_SHORT_NAMES from "../data/hint-regions-short-names.json";
-import { useLayout } from "../context/layoutContext";
 
 const Checks = () => {
   const { state: layoutContext } = useLayout();
@@ -169,7 +170,7 @@ const HintRegion = ({ actions, locations, selectedRegion, setSelectedRegion }) =
     actions.toggleShortcut(selectedRegion);
   };
   const showShortcutToggle =
-    _.includes(DUNGEONS, selectedRegion) && _.isEqual(LogicHelper.settings.dungeon_shortcuts_choice, "random");
+    _.includes(DUNGEON_SHORTCUTS, selectedRegion) && _.isEqual(LogicHelper.settings.dungeon_shortcuts_choice, "random");
   const isShortcutToggled = _.includes(LogicHelper.settings.dungeon_shortcuts, selectedRegion);
 
   const toggleRegion = () => {

--- a/src/utils/locations.js
+++ b/src/utils/locations.js
@@ -109,6 +109,8 @@ class Locations {
     else if (_.isEqual(location.type, "Shop")) {
       if (_.isEqual(LogicHelper.settings.shopsanity, "off")) {
         return false;
+      } else if (_.isEqual(LogicHelper.settings.shopsanity, "random")) {
+        return 4 >= _.toInteger(_.slice(location.locationName, -1));
       } else {
         return _.toInteger(LogicHelper.settings.shopsanity) >= _.toInteger(_.slice(location.locationName, -1));
       }


### PR DESCRIPTION
This PR fixes a few bugs/errors that weren't caught in the last PR:

- A scale has been added to the default layout
- Only dungeons with shortcuts will have the toggleable for dungeon boss shortcuts
- Show four checks per shop when shopsanity is set to random
- Don't throw a warning when the Skull Mask is checked