### PR TITLE
Keep starting items not on layout tracked

### DIFF
--- a/src/data/items.json
+++ b/src/data/items.json
@@ -17,8 +17,6 @@
   "slingshot": "f6eff46730cf46098deddab9d99d7677",
   "slingshot2": "f6eff46730cf46098deddab9d99d7677",
   "slingshot3": "f6eff46730cf46098deddab9d99d7677",
-  "fairy_ocarina": "f965924e0ed740adb07f7ab8e6309002",
-  "time_ocarina": "0031f51287424aee950fd9501ba8707f",
   "bombchus": "22512dafa587497f98cd7135903b09c9",
   "hookshot": "29e0384c520a4e7dad505b48a2156097",
   "hookshot2": "1c9d61dc0b974a55a17120c81dcfb71b",


### PR DESCRIPTION
This PR addresses an issue where an item would be untracked if the player starts with it, but that item is not on the tracker. The behavior now is that items with which the players start but are not on the tracker always remain tracked. I also removed a couple unused uuids for ocarinas.