### PR TITLE
add functionality to duplicate components and elements. Names are not unique

### DIFF
--- a/src/scenes/Editor/EditorComponentsList.js
+++ b/src/scenes/Editor/EditorComponentsList.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import elementsJSON from "../../data/elements.json";
-import { generateId } from "../../utils/utils";
+import { generateId, duplicate } from "../../utils/utils";
 import EditorComponent from "./EditorComponent";
 
 const EditorComponentsList = ({ components, setLayout, customElements }) => {
@@ -52,6 +52,8 @@ const EditorComponentsList = ({ components, setLayout, customElements }) => {
     return [...elementsJSON, ...(customElements || [])];
   }, [customElements]);
 
+  const duplicateComponent = useCallback(() => duplicate(component, components, setComponent), [component, components]);
+
   return (
     <div className="component-list">
       <h5>Components</h5>
@@ -64,6 +66,9 @@ const EditorComponentsList = ({ components, setLayout, customElements }) => {
         </button>
         <button type="button" className="btn btn-light btn-sm" onClick={() => setComponent(null)} disabled={!component}>
           Save
+        </button>
+        <button type="button" className="btn btn-light btn-sm" onClick={duplicateComponent} disabled={!component}>
+          Duplicate
         </button>
       </div>
       {component && (

--- a/src/scenes/Editor/EditorElementsList.js
+++ b/src/scenes/Editor/EditorElementsList.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import Element from "../../components/Element";
-import { generateId, isBase64, splitNameBase64 } from "../../utils/utils";
+import { generateId, isBase64, splitNameBase64, duplicate } from "../../utils/utils";
 import EditorElement from "./EditorElement";
 
 const baseURL = process.env.PUBLIC_URL;
@@ -35,6 +35,8 @@ const EditorElementsList = ({ elements, setLayout }) => {
     });
     setElement(null);
   }, [element, setLayout]);
+
+  const duplicateElements = useCallback(() => duplicate(element, elements, setElement), [element, elements]);
 
   useEffect(() => {
     if (!element) return;
@@ -74,6 +76,9 @@ const EditorElementsList = ({ elements, setLayout }) => {
         </button>
         <button type="button" className="btn btn-light btn-sm" onClick={() => setElement(null)} disabled={!element}>
           Save
+        </button>
+        <button type="button" className="btn btn-light btn-sm" onClick={duplicateElements} disabled={!element}>
+          Duplicate
         </button>
       </div>
       {element && ( // Preview of the element

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -63,3 +63,12 @@ export function updateHintRegionsJSON(files) {
 
   return regions;
 }
+
+export function duplicate(component, components, setComponent) {
+  if (!component) return;
+
+  setComponent({
+    ...component,
+    id: generateId()
+  });
+}


### PR DESCRIPTION
This is a quick change to allow for duplication of components and elements so the user doesn't have to manually duplicate anymore.

Names are not  unique at this moment as there were issues if the user created a name that included the delimiter that was being used

Link to example recording showing the functionality https://youtu.be/OISXNrDytPg