### PR TITLE
Add item tooltips to check locations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:react-hooks/recommended"
+    "plugin:react-hooks/recommended",
+    "plugin:jsdoc/recommended-error"
   ],
   "parserOptions": {
     "ecmaFeatures": {
@@ -17,7 +18,11 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "react-hooks"],
+  "plugins": [
+    "react",
+    "react-hooks",
+    "jsdoc"
+  ],
   "settings": {
     "react": {
       "version": "detect"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20.x'
+
+      - name: Install npm packages
+        run: npm ci
+
+      - name: Build UI
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run eslint
+        run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hashfrog_tracker",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hashfrog_tracker",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "eslint": "^8.15.0",
+        "eslint-plugin-jsdoc": "^62.7.1",
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-react-hooks": "^4.5.0",
         "prettier": "^2.6.2"
@@ -2259,6 +2260,44 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
+      "integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.54.0",
+        "comment-parser": "1.4.5",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -3347,6 +3386,18 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA=="
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
@@ -3897,9 +3948,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
     },
     "node_modules/@types/express": {
       "version": "4.17.17",
@@ -4749,9 +4800,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4952,6 +5003,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/arg": {
@@ -5931,6 +5991,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -6573,11 +6642,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -7476,6 +7545,87 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "62.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.7.1.tgz",
+      "integrity": "sha512-4Zvx99Q7d1uggYBUX/AIjvoyqXhluGbbKrRmG8SQTLprPFg6fa293tVJH1o1GQwNe3lUydd8ZHzn37OaSncgSQ==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.84.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.5",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.1.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.4",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
@@ -7879,9 +8029,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -9028,9 +9178,19 @@
       }
     },
     "node_modules/html-entities": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
-      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -11839,6 +11999,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
+      "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -12405,9 +12574,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -12564,6 +12733,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
+      "integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+      "dev": true
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
@@ -12842,6 +13017,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -12858,6 +13042,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -15116,6 +15306,18 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -15512,11 +15714,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -15747,6 +15944,28 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true
     },
     "node_modules/spdy": {
       "version": "4.0.2",
@@ -16499,6 +16718,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/toidentifier": {
@@ -19317,6 +19552,33 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
+      "integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.54.0",
+        "comment-parser": "1.4.5",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.1.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/types": {
+          "version": "8.57.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+          "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+          "dev": true
+        }
+      }
+    },
+    "@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -20099,6 +20361,12 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA=="
     },
+    "@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
@@ -20487,9 +20755,9 @@
       }
     },
     "@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
     },
     "@types/express": {
       "version": "4.17.17",
@@ -21167,9 +21435,9 @@
       }
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -21308,6 +21576,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true
     },
     "arg": {
       "version": "5.0.2",
@@ -22015,6 +22289,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
+    "comment-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "dev": true
+    },
     "common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -22468,11 +22748,11 @@
       }
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decimal.js": {
@@ -23239,6 +23519,59 @@
         "@typescript-eslint/experimental-utils": "^5.0.0"
       }
     },
+    "eslint-plugin-jsdoc": {
+      "version": "62.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.7.1.tgz",
+      "integrity": "sha512-4Zvx99Q7d1uggYBUX/AIjvoyqXhluGbbKrRmG8SQTLprPFg6fa293tVJH1o1GQwNe3lUydd8ZHzn37OaSncgSQ==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.84.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.5",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.1.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.4",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+          "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+          "dev": true
+        },
+        "espree": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+          "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.16.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^5.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
@@ -23434,9 +23767,9 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "requires": {
         "estraverse": "^5.1.0"
       }
@@ -24287,9 +24620,9 @@
       }
     },
     "html-entities": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
-      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -26299,6 +26632,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
+      "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
+      "dev": true
+    },
     "jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -26728,9 +27067,9 @@
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -26845,6 +27184,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-deep-merge": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
+      "integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+      "dev": true
     },
     "object-hash": {
       "version": "3.0.0",
@@ -27036,6 +27381,15 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "requires": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -27046,6 +27400,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true
     },
     "parse5": {
       "version": "6.0.1",
@@ -28507,6 +28867,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -28769,11 +29135,6 @@
               "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
             }
           }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -28961,6 +29322,28 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
+    "spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true
     },
     "spdy": {
       "version": "4.0.2",
@@ -29520,6 +29903,16 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
       }
     },
     "toidentifier": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "eslint": "^8.15.0",
+    "eslint-plugin-jsdoc": "^62.7.1",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",
     "prettier": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hashfrog_tracker",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "lint": "eslint src/",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,10 @@ import TrackerChecks from "./scenes/TrackerChecks";
 import TrackerLayout from "./scenes/TrackerLayout";
 import Welcome from "./scenes/Welcome";
 
+/**
+ * Root application component with route definitions.
+ * @returns {object} The rendered routes.
+ */
 function App() {
   return (
     <div className="App">

--- a/src/components/RequirementsTooltip.js
+++ b/src/components/RequirementsTooltip.js
@@ -1,0 +1,98 @@
+import React, { useMemo } from "react";
+
+import { getRequirementsStructure, updateRequirementsOwnership } from "../utils/expression-converter";
+
+const RequirementsTooltip = ({ locationName, items }) => {
+  // Compute the requirements once based on starting items only
+  const baseStructure = useMemo(() => {
+    return getRequirementsStructure(locationName);
+  }, [locationName]);
+
+  // Update styling based on current tracked items
+  const { clauses, satisfied } = useMemo(() => {
+    return updateRequirementsOwnership(baseStructure, items);
+  }, [baseStructure, items]);
+
+  // If all requirements are satisfied, show "Nothing"
+  if (satisfied || clauses.length === 0) {
+    return (
+      <div className="requirements-tooltip">
+        <ul>
+          <li className="owned">Nothing</li>
+        </ul>
+      </div>
+    );
+  }
+
+  // Render the inner content of a compound item: subItems joined by
+  // "and", followed by optional nestedOr in parentheses.
+  const renderCompoundContent = (compound, withOuterParens) => {
+    const hasNestedOr = compound.nestedOr && compound.nestedOr.length > 0;
+    return (
+      <>
+        {withOuterParens && <span className="operator">(</span>}
+        {compound.subItems.map((subItem, subIndex) => (
+          <React.Fragment key={subItem.name}>
+            {renderItem(subItem, false)}
+            {subIndex < compound.subItems.length - 1 && (
+              <span className="operator"> and </span>
+            )}
+          </React.Fragment>
+        ))}
+        {hasNestedOr && (
+          <>
+            <span className="operator"> and </span>
+            <span className="operator">(</span>
+            {compound.nestedOr.map((nestedItem, nestedIndex) => (
+              <React.Fragment key={nestedItem.name}>
+                {renderItem(nestedItem, true)}
+                {nestedIndex < compound.nestedOr.length - 1 && (
+                  <span className="operator"> or </span>
+                )}
+              </React.Fragment>
+            ))}
+            <span className="operator">)</span>
+          </>
+        )}
+        {withOuterParens && <span className="operator">)</span>}
+      </>
+    );
+  };
+
+  // Render an item. Compound items with subItems are expanded inline;
+  // needsParens wraps compound content in parentheses for disambiguation.
+  const renderItem = (item, needsParens) => {
+    if (item.isCompound && item.subItems) {
+      return renderCompoundContent(item, needsParens);
+    }
+    return (
+      <span className={item.owned ? "owned" : "missing"}>
+        {item.displayName}
+      </span>
+    );
+  };
+
+  return (
+    <div className="requirements-tooltip">
+      <ul>
+        {clauses.map((clause, clauseIndex) => {
+          const hasMultipleItems = clause.items.length > 1;
+          return (
+            <li key={clauseIndex}>
+              {clause.items.map((item, itemIndex) => (
+                <React.Fragment key={item.name}>
+                  {renderItem(item, hasMultipleItems && item.isCompound)}
+                  {itemIndex < clause.items.length - 1 && (
+                    <span className="operator"> or </span>
+                  )}
+                </React.Fragment>
+              ))}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default RequirementsTooltip;

--- a/src/context/layoutContext.js
+++ b/src/context/layoutContext.js
@@ -2,11 +2,19 @@ import { createContext, useContext, useReducer } from "react";
 
 import defaultLayout from "../layouts/hashfrog.json";
 
+/**
+ * Retrieves the layout from localStorage or returns the default.
+ * @returns {object} The initial layout object.
+ */
 function getInitialLayout() {
   const layout = localStorage.getItem("layout");
   return layout ? JSON.parse(layout) : { ...defaultLayout };
 }
 
+/**
+ * Persists the layout to localStorage.
+ * @param {object} layout - The layout object to cache.
+ */
 function setLayoutCache(layout) {
   const layoutString = JSON.stringify(layout);
   localStorage.setItem("layout", layoutString);
@@ -15,6 +23,12 @@ function setLayoutCache(layout) {
 const initialState = getInitialLayout();
 const LayoutContext = createContext();
 
+/**
+ * Layout context reducer.
+ * @param {object} _state - The current state (unused, replaced by action payload).
+ * @param {object} action - The dispatched action.
+ * @returns {object} The new layout state.
+ */
 function reducer(_state, action) {
   switch (action.type) {
     case "LAYOUT_UPDATE": {
@@ -30,6 +44,11 @@ function reducer(_state, action) {
   }
 }
 
+/**
+ * Provides layout state and dispatch to child components.
+ * @param {object} props - React component props.
+ * @returns {object} The context provider.
+ */
 function LayoutProvider(props) {
   const [state, dispatch] = useReducer(reducer, initialState);
 

--- a/src/context/trackerContext.js
+++ b/src/context/trackerContext.js
@@ -16,6 +16,13 @@ const COMBO_DERIVATIONS = COMBO_ITEMS;
 
 const TrackerContext = createContext();
 
+/**
+ * Converts UUID-based item lists and counters into a logic-compatible items object.
+ * @param {object} items_list - Map of element IDs to item UUIDs.
+ * @param {object} counters - Map of counter names to their values.
+ * @param {Array} unchanged_starting_inventory - Starting inventory UUIDs.
+ * @returns {object} Parsed items keyed by logic item name.
+ */
 function parseItems(items_list, counters, unchanged_starting_inventory) {
   const items = _.cloneDeep(DEFAULT_ITEMS);
   const tradeRevert = !SettingsHelper.getSetting("adult_trade_shuffle") && !SettingsHelper.getRenamedAttribute("disable_trade_revert");
@@ -65,6 +72,12 @@ function parseItems(items_list, counters, unchanged_starting_inventory) {
   return items;
 }
 
+/**
+ * Revalidates location availability based on current items.
+ * @param {object} locations - Map of region names to location data.
+ * @param {object} parsedItems - Parsed items from parseItems.
+ * @returns {object} Cloned locations with updated isAvailable flags.
+ */
 function validateLocations(locations, parsedItems) {
   const clonedLocations = _.cloneDeep(locations);
 
@@ -81,15 +94,27 @@ function validateLocations(locations, parsedItems) {
   return clonedLocations;
 }
 
+/**
+ * Retrieves the cached settings string from localStorage.
+ * @returns {string} The cached settings string, or empty string.
+ */
 function getSettingsStringCache() {
   // Return empty string if no cached value
   return localStorage.getItem("settings_string") || "";
 }
 
+/**
+ * Persists the settings string to localStorage.
+ * @param {string} string - The settings string to cache.
+ */
 function setSettingsStringCache(string) {
   localStorage.setItem("settings_string", string);
 }
 
+/**
+ * Retrieves the cached generator version from localStorage.
+ * @returns {string} The cached version, or the default from env.
+ */
 function getGeneratorVersionCache() {
   let version = localStorage.getItem("generator_version");
   if (!version) {
@@ -99,10 +124,20 @@ function getGeneratorVersionCache() {
   return version;
 }
 
+/**
+ * Persists the generator version to localStorage.
+ * @param {string} version - The generator version string.
+ */
 function setGeneratorVersionCache(version) {
   localStorage.setItem("generator_version", version);
 }
 
+/**
+ * Tracker context reducer handling all state mutations.
+ * @param {object} state - The current tracker state.
+ * @param {object} action - The dispatched action with type and payload.
+ * @returns {object} The new tracker state.
+ */
 function reducer(state, action) {
   const { payload } = action;
   switch (action.type) {
@@ -379,6 +414,11 @@ function reducer(state, action) {
   }
 }
 
+/**
+ * Provides tracker state and dispatch to child components.
+ * @param {object} props - React component props.
+ * @returns {object} The context provider.
+ */
 function TrackerProvider(props) {
   const initialState = {
     locations: {},

--- a/src/data/hint-regions.json
+++ b/src/data/hint-regions.json
@@ -130,7 +130,8 @@
   ],
   "Temple of Time": [
     "Temple of Time",
-    "Beyond Door of Time"
+    "Beyond Door of Time",
+    "Beyond Door of Time Skippable Locations"
   ],
   "Hyrule Castle": [
     "Castle Grounds",
@@ -143,6 +144,7 @@
   "Outside Ganons Castle": [
     "Castle Grounds From Ganons Castle",
     "Ganons Castle Grounds",
+    "Ganons Castle Ledge",
     "OGC Great Fairy Fountain"
   ],
   "Kakariko Village": [
@@ -247,7 +249,8 @@
     "Deku Tree Compass Room",
     "Deku Tree Basement Water Room Front",
     "Deku Tree Basement Water Room Back",
-    "Queen Gohma Boss Room"
+    "Queen Gohma Boss Room",
+    "Queen Gohma Blue Warp"
   ],
   "Dodongos Cavern": [
     "Dodongos Cavern Beginning",
@@ -268,7 +271,8 @@
     "Dodongos Cavern Torch Puzzle Upper",
     "Dodongos Cavern Lower Lizalfos",
     "Dodongos Cavern Poes Room",
-    "King Dodongo Boss Room"
+    "King Dodongo Boss Room",
+    "King Dodongo Blue Warp"
   ],
   "Jabu Jabus Belly": [
     "Jabu Jabus Belly Beginning",
@@ -278,7 +282,8 @@
     "Jabu Jabus Belly Before Boss",
     "Jabu Jabus Belly Elevator Room",
     "Jabu Jabus Belly Before Slimy Thing",
-    "Barinade Boss Room"
+    "Barinade Boss Room",
+    "Barinade Blue Warp"
   ],
   "Forest Temple": [
     "Forest Temple Lobby",
@@ -298,7 +303,8 @@
     "Forest Temple Before Block Puzzle",
     "Forest Temple After Block Puzzle",
     "Forest Temple NE Outdoors Ledge",
-    "Phantom Ganon Boss Room"
+    "Phantom Ganon Boss Room",
+    "Phantom Ganon Blue Warp"
   ],
   "Fire Temple": [
     "Fire Temple Lower",
@@ -318,10 +324,12 @@
     "Fire Temple Block On Fire Room",
     "Fire Temple Shoot Torch On Wall Room",
     "Fire Temple Flame Maze Side Room",
-    "Volvagia Boss Room"
+    "Volvagia Boss Room",
+    "Volvagia Blue Warp"
   ],
   "Water Temple": [
     "Water Temple Lobby",
+    "Water Temple Before Boss Lower",
     "Water Temple Before Boss",
     "Water Temple Dive",
     "Water Temple Lowered Water Levels",
@@ -342,7 +350,8 @@
     "Water Temple Triple Wall Torch",
     "Water Temple Freestanding Key Room",
     "Water Temple Dodongo Room",
-    "Morpha Boss Room"
+    "Morpha Boss Room",
+    "Morpha Blue Warp"
   ],
   "Shadow Temple": [
     "Shadow Temple Entryway",
@@ -367,7 +376,8 @@
     "Shadow Temple Lower Huge Pit",
     "Shadow Temple Across Chasm",
     "Shadow Temple Invisible Maze",
-    "Bongo Bongo Boss Room"
+    "Bongo Bongo Boss Room",
+    "Bongo Bongo Blue Warp"
   ],
   "Spirit Temple": [
     "Spirit Temple Lobby",
@@ -392,7 +402,8 @@
     "Spirit Temple After Shifting Wall",
     "Spirit Temple Mirror Puzzle",
     "Desert Colossus Hands",
-    "Twinrova Boss Room"
+    "Twinrova Boss Room",
+    "Twinrova Blue Warp"
   ],
   "Ganons Castle": [
     "Ganons Castle Lobby",

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
 
+/**
+ * Debounces a value, only updating after the specified delay.
+ * @param {string|number|boolean|object|Array} value - The value to debounce.
+ * @param {number} delay - Delay in milliseconds.
+ * @returns {string|number|boolean|object|Array} The debounced value.
+ */
 function useDebounce(value, delay) {
   // State and setters for debounced value
   const [debouncedValue, setDebouncedValue] = useState(value);

--- a/src/index.css
+++ b/src/index.css
@@ -223,6 +223,45 @@ body {
 }
 
 /** *************************************** */
+/** Requirements Tooltip */
+/** *************************************** */
+
+.requirements-popover {
+  --bs-popover-bg: #212529;
+  --bs-popover-border-color: #495057;
+  --bs-popover-body-color: #ffffff;
+  max-width: 250px;
+  font-size: 0.75rem;
+}
+
+.requirements-popover .popover-body {
+  padding: 0.4rem 0.6rem;
+}
+
+.requirements-tooltip ul {
+  list-style-type: disc;
+  margin: 0;
+  padding-left: 1em;
+}
+
+.requirements-tooltip li {
+  margin: 1px 0;
+  line-height: 1.2;
+}
+
+.requirements-tooltip .owned {
+  color: #ffffff;
+}
+
+.requirements-tooltip .missing {
+  color: #6c757d;
+}
+
+.requirements-tooltip .operator {
+  color: #999;
+}
+
+/** *************************************** */
 /** Editor */
 /** *************************************** */
 

--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -1,6 +1,8 @@
 import _ from "lodash";
 import { useEffect, useMemo, useState } from "react";
+import { OverlayTrigger, Popover } from "react-bootstrap";
 
+import RequirementsTooltip from "../components/RequirementsTooltip";
 import { useLayout } from "../context/layoutContext";
 import { useChecks, useLocation } from "../context/trackerContext";
 import DUNGEON_CONFIG from "../data/dungeon-config.json";
@@ -103,6 +105,7 @@ const Checks = () => {
       <LocationsList
         actions={actions}
         countLocations={countLocations}
+        items={items}
         locations={locations}
         onRegionClicked={onRegionClicked}
         selectedRegion={selectedRegion}
@@ -137,24 +140,42 @@ const Buttons = ({ type, setType }) => {
   );
 };
 
-const HintRegion = ({ actions, locations, selectedRegion, setSelectedRegion }) => {
+const HintRegion = ({ actions, items, locations, selectedRegion, setSelectedRegion }) => {
   const locationsList = _.map(locations[selectedRegion], (locationData, locationName) => {
     const style = {};
     if (locationData.isChecked) { style.textDecoration = "line-through"; }
     if (!locationData.isAvailable) { style.opacity = "0.5"; }
+
+    const displayName = Locations.removeRegionPrefix(locationName, selectedRegion);
+
+    const popover = (
+      <Popover id={`popover-${locationName}`} className="requirements-popover">
+        <Popover.Body>
+          <RequirementsTooltip locationName={locationName} items={items} />
+        </Popover.Body>
+      </Popover>
+    );
+
     return (
       <li key={locationName} className="check">
-        <button
-          type="button"
-          style={style}
-          onClick={() => actions.markLocation(locationName, selectedRegion)}
-          onContextMenu={e => {
-            e.preventDefault();
-            actions.markLocation(locationName, selectedRegion);
-          }}
+        <OverlayTrigger
+          trigger={["hover", "focus"]}
+          placement="auto"
+          delay={{ show: 300, hide: 0 }}
+          overlay={popover}
         >
-          {Locations.removeRegionPrefix(locationName, selectedRegion)}
-        </button>
+          <button
+            type="button"
+            style={style}
+            onClick={() => actions.markLocation(locationName, selectedRegion)}
+            onContextMenu={e => {
+              e.preventDefault();
+              actions.markLocation(locationName, selectedRegion);
+            }}
+          >
+            {displayName}
+          </button>
+        </OverlayTrigger>
       </li>
     );
   });
@@ -209,6 +230,7 @@ const HintRegion = ({ actions, locations, selectedRegion, setSelectedRegion }) =
 const LocationsList = ({
   actions,
   countLocations,
+  items,
   locations,
   onRegionClicked,
   selectedRegion,
@@ -219,6 +241,7 @@ const LocationsList = ({
     return (
       <HintRegion
         actions={actions}
+        items={items}
         locations={locations}
         selectedRegion={selectedRegion}
         setSelectedRegion={setSelectedRegion}

--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -41,8 +41,8 @@ const Checks = () => {
         // so that the user can toggle to MQ.
         if (!locationAddedForRegion && _.includes(DUNGEONS, regionName)) {
           const showMQToggle =
-            _.isEqual(SettingsHelper.getSetting("mq_dungeons_mode"), "random") ||
-            (_.isEqual(SettingsHelper.getSetting("mq_dungeons_mode"), "count") && SettingsHelper.getSetting("mq_dungeons_count") > 0);
+            SettingsHelper.getSetting("mq_dungeons_mode") === "random" ||
+            (SettingsHelper.getSetting("mq_dungeons_mode") === "count" && SettingsHelper.getSetting("mq_dungeons_count") > 0);
 
           const hasPossibleLocations =
             _.some(_.values(Locations.locations.dungeon[regionName]), locationData => {
@@ -92,7 +92,7 @@ const Checks = () => {
   }, [locations]);
 
   const onRegionClicked = regionName => {
-    setSelectedRegion(prev => (_.isEqual(prev, regionName) ? null : regionName));
+    setSelectedRegion(prev => (prev === regionName ? null : regionName));
   };
 
   useEffect(() => {
@@ -208,19 +208,15 @@ const HintRegion = ({ actions, items, locations, selectedRegion, setSelectedRegi
       <button type="button" className="btn btn-dark btn-sm py-0 mb-2 me-1" onClick={toggleRegion}>
         Toggle All
       </button>
-      {showMQToggle ? (
+      {showMQToggle && (
         <button type="button" className="btn btn-dark btn-sm py-0 mb-2 me-1" onClick={toggleMQ}>
           {isMQToggled ? "MQ: On" : "MQ: Off"}
         </button>
-      ) : (
-        ""
       )}
-      {showShortcutToggle ? (
+      {showShortcutToggle && (
         <button type="button" className="btn btn-dark btn-sm py-0 mb-2 me-1" onClick={toggleShortcut}>
           {isShortcutToggled ? "Shortcut: On" : "Shortcut: Off"}
         </button>
-      ) : (
-        ""
       )}
       <ul className="check-list">{locationsList}</ul>
     </div>
@@ -267,7 +263,6 @@ const LocationsList = ({
         checked: 0,
         available: 0,
         remaining: 0,
-        skulls: 0,
       };
       countLocations(locationData, locationsCounter);
 

--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -244,19 +244,12 @@ const LocationsList = ({
       />
     );
   } else {
-    const filteredLocations = _.filter(_.keys(locations), regionName => {
-      if (_.isEqual(type, "dungeon")) {
-        return _.includes(DUNGEONS, regionName);
-      } else {
-        return !_.includes(DUNGEONS, regionName);
-      }
-    });
+    const regionNames = _.keys(locations).filter(regionName =>
+      type === "dungeon" ? _.includes(DUNGEONS, regionName) : !_.includes(DUNGEONS, regionName)
+    );
 
-    const locationsList = _.map(locations, (locationData, regionName) => {
-      if (!_.includes(filteredLocations, regionName)) {
-        return;
-      }
-
+    const locationsList = regionNames.map(regionName => {
+      const locationData = locations[regionName];
       const numLocations = _.size(locationData);
       const locationsCounter = {
         locked: 0,

--- a/src/scenes/Editor/Editor.js
+++ b/src/scenes/Editor/Editor.js
@@ -8,6 +8,11 @@ import EditorComponentsList from "./EditorComponentsList";
 import EditorElementsList from "./EditorElementsList";
 import EditorLayoutConfig from "./EditorLayoutConfig";
 
+/**
+ * Normalizes a raw layout by applying default values to each component.
+ * @param {object} rawLayout - The raw layout JSON object.
+ * @returns {object} The prepared layout with defaults applied.
+ */
 function prepareLayout(rawLayout) {
   const cleanedComponents = [
     ...rawLayout.components.map(component => {

--- a/src/scenes/Welcome.js
+++ b/src/scenes/Welcome.js
@@ -55,7 +55,8 @@ const Welcome = () => {
                 <ul className="mb-0 ps-3">
                   <li className="mb-2">Layout customization, UI editor, custom elements/icons and more.</li>
                   <li className="mb-2">Store and share layout configuration in JSON files.</li>
-                  <li>Check/Location tracking based on the randomizer generator logic.</li>
+                  <li className="mb-2">Check/Location tracking based on the randomizer generator logic.</li>
+                  <li className="mb-2">Item requirement tooltips on check locations.</li>
                 </ul>
               </Accordion.Body>
             </Accordion.Item>
@@ -66,7 +67,11 @@ const Welcome = () => {
               <Accordion.Body className="bg-dark text-light">
                 <ul className="list-unstyled mb-0">
                   <li className="mb-2">
-                    <Badge bg="success" className="me-2">0.7.0</Badge>
+                    <Badge bg="success" className="me-2">0.7.1</Badge>
+                    <span className="small">Add item requirement tooltips on check locations, showing what items are needed with tracked items highlighted.</span>
+                  </li>
+                  <li className="mb-2">
+                    <Badge bg="secondary" className="me-2">0.7.0</Badge>
                     <span className="small">Logic updates, performance improvements for check tracking, multi-version support, new look for launcher page, updated key icons, and fixes for starting inventory.</span>
                   </li>
                   <li className="mb-2">

--- a/src/utils/dnf-paths.js
+++ b/src/utils/dnf-paths.js
@@ -1,0 +1,182 @@
+import {
+  Clause, Expression, RequirementItem,
+  getDisplayName,
+  impossibleExpr, orCombineExpressions,
+  parseCountedItem,
+} from "./expression-data";
+
+
+/**
+ * Convert a CNF Expression to a list of DNF paths.
+ * @param {Expression} expr - The CNF Expression to convert.
+ * @returns {Array<Array>} List of DNF paths, each a sorted array of item name strings.
+ */
+function expressionToDNFPaths(expr) {
+  if (expr.isEmpty()) {
+    return [[]];
+  }
+
+  let paths = [[]];
+
+  for (const clause of expr.clauses) {
+    const validItems = clause.items.filter(item => item.name !== "__false__");
+    if (validItems.length === 0) {
+      return [];
+    }
+
+    const newPaths = [];
+    for (const item of validItems) {
+      const itemName = item.name;
+      for (const path of paths) {
+        if (path.includes(itemName)) {
+          newPaths.push(path);
+        } else {
+          newPaths.push([...path, itemName].sort());
+        }
+      }
+    }
+    paths = pruneDominatedDNFPaths(newPaths);
+
+    // Safety cap to prevent exponential blowup on complex exit rules
+    if (paths.length > 50) {
+      paths.sort((a, b) => a.length - b.length);
+      paths = paths.slice(0, 30);
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Merge two sorted item arrays into a sorted, deduplicated array.
+ * @param {Array} a - First sorted item name array.
+ * @param {Array} b - Second sorted item name array.
+ * @returns {Array} The merged, deduplicated, sorted array.
+ */
+function mergeSortedPaths(a, b) {
+  if (a.length === 0) { return b; }
+  if (b.length === 0) { return a; }
+
+  const items = buildPathMap([...a, ...b]);
+  return [...items.entries()]
+    .map(([base, count]) => (count > 1 ? `${base},${count}` : base))
+    .sort();
+}
+
+/**
+ * Combine source DNF paths with exit DNF paths.
+ * @param {Array<Array>} sourcePaths - The source region's DNF paths.
+ * @param {Array<Array>} exitPaths - The exit rule's DNF paths.
+ * @returns {Array<Array>} The combined DNF paths.
+ */
+function combineDNFPaths(sourcePaths, exitPaths) {
+  const result = [];
+  for (const src of sourcePaths) {
+    for (const exit of exitPaths) {
+      result.push(mergeSortedPaths(src, exit));
+    }
+  }
+  return result;
+}
+
+/**
+ * Build a Map of baseName to maxCount for a DNF path.
+ * @param {Array} path - A sorted array of item name strings.
+ * @returns {Map<string, number>} The path map.
+ */
+function buildPathMap(path) {
+  const map = new Map();
+  for (const name of path) {
+    const { baseName, count } = parseCountedItem(name);
+    map.set(baseName, Math.max(map.get(baseName) || 0, count));
+  }
+  return map;
+}
+
+/**
+ * Check if path 'a' is a subset of path 'b' (a dominates b).
+ * @param {Array} a - The candidate subset path.
+ * @param {Map} bMap - Pre-built path map for b (from buildPathMap).
+ * @returns {boolean} True if every item in a is satisfied by b.
+ */
+function isPathSubsetOf(a, bMap) {
+  for (const name of a) {
+    const { baseName, count } = parseCountedItem(name);
+    if ((bMap.get(baseName) || 0) < count) { return false; }
+  }
+  return true;
+}
+
+/**
+ * Prune dominated paths. Path A dominates B if A is a strict subset of B.
+ * @param {Array<Array>} paths - The list of DNF paths to prune.
+ * @returns {Array<Array>} The pruned list with dominated paths removed.
+ */
+function pruneDominatedDNFPaths(paths) {
+  if (paths.length <= 1) { return paths; }
+
+  const unique = new Map();
+  for (const path of paths) {
+    const key = path.join(",");
+    if (!unique.has(key)) { unique.set(key, path); }
+  }
+
+  const allPaths = [...unique.values()];
+  if (allPaths.length <= 1) { return allPaths; }
+
+  // Pre-build maps so isPathSubsetOf doesn't rebuild them on every comparison
+  const pathMaps = allPaths.map(buildPathMap);
+
+  // After dedup, i !== j guarantees truly different paths,
+  // so isPathSubsetOf returning true implies strict subset.
+  return allPaths.filter((path, i) =>
+    !allPaths.some((other, j) => i !== j && other.length <= path.length && isPathSubsetOf(other, pathMaps[i]))
+  );
+}
+
+/**
+ * Check if two DNF path sets are equal.
+ * @param {Array<Array>} a - The first DNF path set.
+ * @param {Array<Array>} b - The second DNF path set.
+ * @returns {boolean} True if both sets contain the same paths.
+ */
+function dnfPathSetsEqual(a, b) {
+  if (a.length !== b.length) { return false; }
+  const aKeys = new Set(a.map(p => p.join(",")));
+  return b.every(p => aKeys.has(p.join(",")));
+}
+
+/**
+ * Convert DNF paths back to a CNF Expression.
+ * @param {Array<Array>} paths - The list of DNF paths to convert.
+ * @returns {Expression} The resulting CNF Expression.
+ */
+function dnfPathsToExpression(paths) {
+  if (paths.length === 0) {
+    return impossibleExpr();
+  }
+
+  // Sort by size for better absorption
+  const sorted = [...paths].sort((a, b) => a.length - b.length);
+
+  const pathToExpr = (path) => {
+    if (path.length === 0) { return new Expression(); }
+    return new Expression(path.map(name => {
+      const { baseName, count } = parseCountedItem(name);
+      const display = (count > 1 && baseName !== "Magic_Bean") ? `${getDisplayName(baseName)} x${count}` : getDisplayName(baseName);
+      return new Clause([new RequirementItem(name, display, false)]);
+    }));
+  };
+
+  let result = pathToExpr(sorted[0]);
+  for (let i = 1; i < sorted.length; i++) {
+    result = orCombineExpressions(result, pathToExpr(sorted[i]));
+  }
+  result.simplify();
+  return result;
+}
+
+export {
+  combineDNFPaths, dnfPathSetsEqual,
+  dnfPathsToExpression, expressionToDNFPaths, pruneDominatedDNFPaths
+};

--- a/src/utils/dnf-paths.test.js
+++ b/src/utils/dnf-paths.test.js
@@ -1,0 +1,261 @@
+import {
+  combineDNFPaths, dnfPathSetsEqual,
+  dnfPathsToExpression, expressionToDNFPaths, pruneDominatedDNFPaths,
+} from "./dnf-paths";
+import {
+  Clause, Expression, RequirementItem, impossibleExpr,
+} from "./expression-data";
+
+
+// Convenience factories
+const ri = (name) => new RequirementItem(name, name, false);
+const clause = (...names) => new Clause(names.map(n => ri(n)));
+const expr = (...clauseItemLists) =>
+  new Expression(clauseItemLists.map(items => clause(...items)));
+
+
+describe("expressionToDNFPaths", () => {
+  test("empty expression returns [[]] (one empty path)", () => {
+    expect(expressionToDNFPaths(new Expression())).toEqual([[]]);
+  });
+
+  test("impossible expression (all-false clause) returns []", () => {
+    const e = impossibleExpr();
+    expect(expressionToDNFPaths(e)).toEqual([]);
+  });
+
+  test("single clause, single item", () => {
+    const e = expr(["A"]);
+    expect(expressionToDNFPaths(e)).toEqual([["A"]]);
+  });
+
+  test("single clause, multiple items (OR)", () => {
+    const e = expr(["A", "B"]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toHaveLength(2);
+    expect(paths).toContainEqual(["A"]);
+    expect(paths).toContainEqual(["B"]);
+  });
+
+  test("two single-item clauses (AND)", () => {
+    const e = expr(["A"], ["B"]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toEqual([["A", "B"]]);
+  });
+
+  test("two multi-item clauses produce cross-product paths", () => {
+    const e = expr(["A", "B"], ["C", "D"]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toHaveLength(4);
+    expect(paths).toContainEqual(["A", "C"]);
+    expect(paths).toContainEqual(["A", "D"]);
+    expect(paths).toContainEqual(["B", "C"]);
+    expect(paths).toContainEqual(["B", "D"]);
+  });
+
+  test("paths are sorted alphabetically within each path", () => {
+    const e = expr(["C"], ["A"]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toEqual([["A", "C"]]);
+  });
+
+  test("shared items do not duplicate in merged paths", () => {
+    const e = expr(["A", "B"], ["A", "C"]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toContainEqual(["A"]);
+    expect(paths).toContainEqual(["B", "C"]);
+  });
+
+  test("prunes dominated paths during expansion", () => {
+    const e = expr(["A"], ["A", "B"]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toEqual([["A"]]);
+  });
+
+  test("handles clause with mix of false and valid items", () => {
+    const falseRi = new RequirementItem("__false__", "false", false);
+    const e = new Expression([new Clause([falseRi, ri("A")])]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toEqual([["A"]]);
+  });
+
+  test("handles counted items in paths", () => {
+    const hook2 = new RequirementItem("Progressive_Hookshot,2", "Longshot", false);
+    const e = new Expression([new Clause([hook2])]);
+    const paths = expressionToDNFPaths(e);
+    expect(paths).toEqual([["Progressive_Hookshot,2"]]);
+  });
+
+  test(">50 paths truncated to 30 shortest", () => {
+    const clauses = [];
+    for (let i = 0; i < 6; i++) {
+      clauses.push(new Clause([ri(`X${i}`), ri(`Y${i}`)]));
+    }
+    const e = new Expression(clauses);
+    const paths = expressionToDNFPaths(e);
+    expect(paths.length).toBeLessThanOrEqual(30);
+  });
+});
+
+
+describe("combineDNFPaths", () => {
+  test("single path x single path", () => {
+    const result = combineDNFPaths([["A"]], [["B"]]);
+    expect(result).toEqual([["A", "B"]]);
+  });
+
+  test("cartesian product of multiple paths", () => {
+    const result = combineDNFPaths([["A"], ["B"]], [["C"], ["D"]]);
+    expect(result).toHaveLength(4);
+    expect(result).toContainEqual(["A", "C"]);
+    expect(result).toContainEqual(["A", "D"]);
+    expect(result).toContainEqual(["B", "C"]);
+    expect(result).toContainEqual(["B", "D"]);
+  });
+
+  test("merges overlapping items (dedup)", () => {
+    const result = combineDNFPaths([["A", "B"]], [["B", "C"]]);
+    expect(result).toEqual([["A", "B", "C"]]);
+  });
+
+  test("counted items: keeps max count", () => {
+    const result = combineDNFPaths(
+      [["Progressive_Hookshot,2"]],
+      [["Progressive_Hookshot,1"]],
+    );
+    expect(result).toEqual([["Progressive_Hookshot,2"]]);
+  });
+
+  test("empty source paths produce empty result", () => {
+    expect(combineDNFPaths([], [["A"]])).toEqual([]);
+  });
+
+  test("empty exit paths produce empty result", () => {
+    expect(combineDNFPaths([["A"]], [])).toEqual([]);
+  });
+
+  test("empty path in array passes through other side", () => {
+    const result = combineDNFPaths([[]], [["A"]]);
+    expect(result).toEqual([["A"]]);
+  });
+});
+
+
+describe("pruneDominatedDNFPaths", () => {
+  test("single path unchanged", () => {
+    expect(pruneDominatedDNFPaths([["A"]])).toEqual([["A"]]);
+  });
+
+  test("removes dominated path (superset)", () => {
+    const result = pruneDominatedDNFPaths([["A"], ["A", "B"]]);
+    expect(result).toEqual([["A"]]);
+  });
+
+  test("keeps non-dominated (unrelated) paths", () => {
+    const result = pruneDominatedDNFPaths([["A"], ["B"]]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("removes exact duplicates", () => {
+    const result = pruneDominatedDNFPaths([["A", "B"], ["A", "B"]]);
+    expect(result).toEqual([["A", "B"]]);
+  });
+
+  test("counted items: lower count dominates higher", () => {
+    const result = pruneDominatedDNFPaths([
+      ["Progressive_Hookshot,1"],
+      ["Progressive_Hookshot,2"],
+    ]);
+    expect(result).toEqual([["Progressive_Hookshot,1"]]);
+  });
+
+  test("multi-level domination", () => {
+    const result = pruneDominatedDNFPaths([
+      ["A"],
+      ["A", "B"],
+      ["A", "B", "C"],
+    ]);
+    expect(result).toEqual([["A"]]);
+  });
+
+  test("mutual non-domination preserved", () => {
+    const result = pruneDominatedDNFPaths([["A", "B"], ["B", "C"]]);
+    expect(result).toHaveLength(2);
+  });
+});
+
+
+describe("dnfPathSetsEqual", () => {
+  test("identical sets return true", () => {
+    expect(dnfPathSetsEqual([["A"], ["B"]], [["A"], ["B"]])).toBe(true);
+  });
+
+  test("same paths different order return true", () => {
+    expect(dnfPathSetsEqual([["A"], ["B"]], [["B"], ["A"]])).toBe(true);
+  });
+
+  test("different lengths return false", () => {
+    expect(dnfPathSetsEqual([["A"]], [["A"], ["B"]])).toBe(false);
+  });
+
+  test("different paths return false", () => {
+    expect(dnfPathSetsEqual([["A"]], [["B"]])).toBe(false);
+  });
+
+  test("both empty return true", () => {
+    expect(dnfPathSetsEqual([], [])).toBe(true);
+  });
+
+  test("multi-item paths with different contents return false", () => {
+    expect(dnfPathSetsEqual([["A", "B"]], [["A", "C"]])).toBe(false);
+  });
+});
+
+
+describe("dnfPathsToExpression", () => {
+  test("empty paths returns impossible expression", () => {
+    expect(dnfPathsToExpression([]).isImpossible()).toBe(true);
+  });
+
+  test("single empty path returns empty (satisfied) expression", () => {
+    expect(dnfPathsToExpression([[]]).isEmpty()).toBe(true);
+  });
+
+  test("single path, single item produces one-clause expression", () => {
+    const result = dnfPathsToExpression([["Bow"]]);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items[0].name).toBe("Bow");
+  });
+
+  test("single path, multiple items produces multiple AND clauses", () => {
+    const result = dnfPathsToExpression([["Bow", "Hookshot"]]);
+    expect(result.clauses.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("multiple paths are OR-combined", () => {
+    const result = dnfPathsToExpression([["A"], ["B"]]);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items).toHaveLength(2);
+  });
+
+  test("counted item gets x2 display suffix", () => {
+    const result = dnfPathsToExpression([["Progressive_Hookshot,2"]]);
+    expect(result.clauses[0].items[0].displayName).toBe("Hookshot x2");
+  });
+
+  test("Magic_Bean counted does NOT get xN suffix", () => {
+    const result = dnfPathsToExpression([["Magic_Bean,5"]]);
+    expect(result.clauses[0].items[0].displayName).toBe("Magic Bean");
+  });
+
+  test("result is simplified (redundancies removed)", () => {
+    const result = dnfPathsToExpression([["A"], ["A", "B"]]);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items[0].name).toBe("A");
+  });
+
+  test("uses getDisplayName for proper display names", () => {
+    const result = dnfPathsToExpression([["Bomb_Bag"]]);
+    expect(result.clauses[0].items[0].displayName).toBe("Bombs");
+  });
+});

--- a/src/utils/expression-converter.js
+++ b/src/utils/expression-converter.js
@@ -1,0 +1,2358 @@
+import GAME_REWARDS from "../data/game-rewards.json";
+import shopRules from "../data/shop-rules.json";
+import {
+  combineDNFPaths,
+  dnfPathSetsEqual, dnfPathsToExpression,
+  expressionToDNFPaths,
+  pruneDominatedDNFPaths,
+} from "./dnf-paths";
+import {
+  Clause,
+  CompoundItem,
+  Expression,
+  RequirementItem,
+  combineWithOr,
+  getDisplayName,
+  impossibleExpr, orCombineExpressions,
+  simplifyOrBySubset,
+} from "./expression-data";
+import Locations from "./locations";
+import LogicHelper from "./logic-helper";
+import { parseRule } from "./rule-parser";
+import SettingsHelper from "./settings-helper";
+
+
+// Category-based counts for has_medallions, has_stones, etc.
+const CATEGORY_ITEMS = {
+  "Medallions": GAME_REWARDS.medallions,
+  "Stones": GAME_REWARDS.stones,
+  "Dungeon Rewards": GAME_REWARDS.dungeonRewards,
+};
+
+// Items that can only be used by adult Link.
+// Note: "Longshot" is a rule alias that expands before reaching item name structures, so it is never present here.
+const ADULT_ONLY_ITEMS = new Set([
+  "Megaton_Hammer", "Progressive_Hookshot", "Iron_Boots", "Hover_Boots", "Mirror_Shield",
+  "Bow", "Fire_Arrows", "Ice_Arrows", "Light_Arrows", "Master_Sword", "Biggoron_Sword", "Goron_Tunic", "Zora_Tunic",
+]);
+
+// Items that can only be used by child Link.
+const CHILD_ONLY_ITEMS = new Set([
+  "Slingshot", "Boomerang", "Kokiri_Sword", "Deku_Shield", "Magic_Bean",
+]);
+
+// Regions that are always reachable without any items.
+const ENTRY_POINT_REGIONS = new Set(["Root", "Root Exits", "Child Spawn", "Adult Spawn"]);
+
+// Farore's Wind Warp is a dynamic save warp.
+// Unlike song warps (which have fixed destinations), this creates spurious paths in our BFS. Exclude it entirely.
+const EXCLUDED_FROM_PATHFINDING = new Set(["Farores Wind Warp"]);
+
+// Map of event/location names to the flags they produce.
+// Used for cycle detection when expanding events.
+const EVENT_TO_FLAG = {
+  "Deliver Rutos Letter": ["Deliver_Letter", "Deliver Letter"],
+  "Pierre": ["Scarecrow_Song", "Scarecrow Song"],
+  "Master Sword Pedestal": ["Time_Travel", "Time Travel"],
+};
+
+// Reverse mapping: flag name -> source event/location name.
+// Used to expand event flags (like "Deliver Letter") into their producing location's requirements.
+const FLAG_TO_EVENT = {};
+for (const [eventName, flags] of Object.entries(EVENT_TO_FLAG)) {
+  for (const flag of flags) {
+    FLAG_TO_EVENT[flag] = eventName;
+  }
+}
+
+// Ordered lookup for key/rupee shuffle settings.
+// Specific prefixes must precede generic ones so first-match-wins is correct.
+const KEY_SHUFFLE_RULES = [
+  { prefix: "Small_Key_Treasure_Chest_Game", setting: "shuffle_tcgkeys", vanillaLabel: "Small Key (Treasure Chest Game)" },
+  { prefix: "Small_Key_Thieves_Hideout", setting: "shuffle_hideoutkeys", vanillaLabel: "Small Key (Thieves Hideout)" },
+  { prefix: "Small_Key_", setting: "shuffle_smallkeys", vanillaLabel: null },
+  { prefix: "Boss_Key_Ganons_Castle", setting: "shuffle_ganon_bosskey", vanillaLabel: "Boss Key (Ganons Castle)", exact: true },
+  { prefix: "Boss_Key_", setting: "shuffle_bosskeys", vanillaLabel: null },
+  { prefix: "Silver_Rupee_", setting: "shuffle_silver_rupees", vanillaLabel: null },
+];
+
+// Drops that require effort to obtain and should not be auto-satisfied during tooltip evaluation.
+// All other drops are treated as free.
+const NON_FREE_DROPS = new Set(["Blue Fire"]);
+
+// Logic identifiers for individual ocarina buttons.
+const OCARINA_NOTE_IDENTIFIERS = new Set([
+  "Ocarina_A_Button", "Ocarina_C_up_Button", "Ocarina_C_down_Button", "Ocarina_C_left_Button", "Ocarina_C_right_Button",
+]);
+
+// Identifier prefixes that always refer to settings flags, not collectible items.
+// Used to short-circuit evaluation for these identifiers without checking the item list.
+const SETTINGS_PREFIXES = new Set(["logic_", "at_", "adv_", "glitch_"]);
+
+// Logic identifiers that are always auto-satisfied or otherwise irrelevant to tooltip display.
+const SKIP_IDENTIFIERS = new Set([
+  "True", "is_starting_age", "had_night_start", "Scarecrow_Song", "Bonooru", "Time_Travel",
+]);
+
+// Item name prefixes to silently skip.
+const SKIP_PREFIXES = new Set(["Bombchu_", "Bombchus_", "Buy_"]);
+
+// Shop items that require an empty bottle to purchase.
+const SHOP_BOTTLE_REQUIRED = new Set(shopRules.bottleRequired || []);
+
+// Shop items that require one or two wallet upgrades to afford.
+const SHOP_WALLET_REQUIREMENTS = new Map();
+for (const item of shopRules.walletRequired || []) {
+  SHOP_WALLET_REQUIREMENTS.set(item, { id: "Progressive_Wallet", label: "Wallet", count: 1 });
+}
+for (const item of shopRules.wallet2Required || []) {
+  SHOP_WALLET_REQUIREMENTS.set(item, { id: "Progressive_Wallet,2", label: "Wallet x2", count: 2 });
+}
+
+// Logic rules sometimes reference items as string literals rather than identifiers.
+// Maps the string form back to the canonical logic item name.
+const STRING_LITERAL_ITEMS = {
+  "Goron Tunic": "Goron_Tunic",
+  "Zora Tunic": "Zora_Tunic",
+};
+
+
+// Age context for the current extraction pass.
+// null = any age, "adult" = adult only, "child" = child only
+let currentAgeContext = null;
+
+// Settings cache for the current evaluation.
+let cachedSettings = null;
+
+// Expansion cache for the current evaluation.
+let evaluationCache = null;
+
+// Requirement structures keyed by location name. Invalidated when settings change.
+const structureCache = new Map();
+let lastSettingsJson = null;
+
+// Region accessibility caches, one per age context. Each maps regionName -> Expression.
+// Built once per settings change via BFS, then reused for all location evaluations.
+let regionCacheChild = null;
+let regionCacheAdult = null;
+
+// Flag active during region cache building.
+// Keeps drops auto-satisfied so aliases don't propagate spurious requirements.
+let regionCacheBuildingMode = false;
+
+// In-progress region cache exposed during BFS.
+// Makes partially-built regions visible to expandEvent, expandDrop, and at() within the same BFS pass.
+let activeRegionCacheOverride = null;
+
+// Child region access expression for bean planting locations that carry an explicit age requirement.
+let beanPlantingChildRegionExpr = null;
+
+// Previous BFS iteration's region cache, used by at() during cache building. Prevents cyclic feedback.
+let bfsAtLookupCache = null;
+
+
+/**
+ * Factor common items from compound options within an OR clause.
+ * 
+ * Unlike factorCommonFromOrOptions, this only factors from compound items, leaving simple items untouched.
+ * @param {Array} items - Array of items in an OR clause.
+ * @returns {Array} Simplified array with compounds factored.
+ */
+function factorCompoundsWithSharedItems(items) {
+  if (items.length <= 1) {
+    return items;
+  }
+
+  // Separate simple items from compound items
+  const simpleItems = items.filter(item => !item.isCompound);
+  const compoundItems = items.filter(item => item.isCompound && item.items && item.items.length > 0);
+
+  // Need at least 2 compounds to factor
+  if (compoundItems.length < 2) {
+    return items;
+  }
+
+  // Find items that appear in ALL compound items
+  const firstCompoundNames = new Set(compoundItems[0].items.map(i => i.name));
+  const commonNames = [...firstCompoundNames].filter(name =>
+    compoundItems.every(compound =>
+      compound.items.some(i => i.name === name)
+    )
+  );
+
+  // Need at least one common item to factor
+  if (commonNames.length === 0) {
+    return items;
+  }
+
+  // Get the common item objects from the first compound
+  const commonItems = compoundItems[0].items.filter(i => commonNames.includes(i.name));
+
+  // Build the remaining OR options
+  const nestedOrItems = compoundItems.map(compound => {
+    const remainingItems = compound.items.filter(i => !commonNames.includes(i.name));
+    if (remainingItems.length === 0) {
+      // Entire compound was common items
+      return null;
+    }
+    if (remainingItems.length === 1) {
+      // Single item
+      return remainingItems[0];
+    }
+
+    return new CompoundItem(remainingItems);
+  }).filter(item => item !== null);
+
+  // Deduplicate nested OR items by name
+  const seenNames = new Set();
+  const dedupedNestedOr = nestedOrItems.filter(item => {
+    if (seenNames.has(item.name)) { return false; }
+    seenNames.add(item.name);
+    return true;
+  });
+
+  // If there's only one unique nested option after factoring, just combine with common items
+  if (dedupedNestedOr.length <= 1) {
+    if (dedupedNestedOr.length === 1) {
+      // Create a single compound from common + remaining
+      const allItems = [...commonItems];
+      if (dedupedNestedOr[0].isCompound) {
+        allItems.push(...dedupedNestedOr[0].items);
+      } else {
+        allItems.push(dedupedNestedOr[0]);
+      }
+      return [...simpleItems, new CompoundItem(allItems)];
+    }
+
+    // Create compound from remaining common items
+    return [...simpleItems, new CompoundItem(commonItems)];
+  }
+
+  // Create a compound with nested OR structure
+  const nestedCompound = new CompoundItem(commonItems);
+  nestedCompound.nestedOr = dedupedNestedOr;
+
+  // Update display name to show nested structure
+  const nestedOrDisplay = dedupedNestedOr.map(item =>
+    item.isCompound ? `(${item.displayName})` : item.displayName
+  ).join(" or ");
+  nestedCompound.displayName = `${nestedCompound.displayName} and (${nestedOrDisplay})`;
+
+  // Update name for deduplication
+  const nestedOrName = dedupedNestedOr.map(item => item.name).sort().join("|");
+  nestedCompound.name = `${nestedCompound.name}+(${nestedOrName})`;
+
+  // Update owned status
+  nestedCompound.owned = commonItems.every(i => i.owned) &&
+    dedupedNestedOr.some(item => item.owned);
+
+  return [...simpleItems, nestedCompound];
+}
+
+/**
+ * Remove redundant top-level age clauses that are already implied by item age restrictions.
+ *
+ * When a clause contains an item that only works for one age, a separate is_adult clause is redundant and can be
+ * removed.
+ * @param {Array} clauses - Output-format clause objects with items arrays.
+ * @returns {Array} Simplified clause array with implied age clauses removed.
+ */
+function simplifyTopLevelAge(clauses) {
+  // Collect implied ages from all clauses in the original array
+  const impliedAges = new Set();
+
+  clauses.forEach((clause) => {
+    if (clause.items.length === 1) {
+      const item = clause.items[0];
+      if (item.name !== "is_adult" && item.name !== "is_child") {
+        const implied = getItemImpliedAge(item.name);
+        if (implied) {
+          impliedAges.add(implied);
+        }
+      }
+    }
+
+    // Also check compounds and multi-item clauses for age implications
+    clause.items.forEach(item => {
+      if (item.isCompound && item.subItems) {
+        item.subItems.forEach(subItem => {
+          const implied = getItemImpliedAge(subItem.name);
+          if (implied) {
+            impliedAges.add(implied);
+          }
+        });
+      } else if (item.name !== "is_adult" && item.name !== "is_child") {
+        const implied = getItemImpliedAge(item.name);
+        if (implied) {
+          impliedAges.add(implied);
+        }
+      }
+    });
+  });
+
+  // First, simplify compounds based on implied ages from other clauses
+  const simplifiedClauses = clauses.map(clause => ({
+    items: clause.items.map(item => {
+      if (item.isCompound && item.subItems) {
+        // Filter age from compound if implied by other clauses
+        const filteredSubItems = item.subItems.filter(subItem => {
+          if (subItem.name === "is_adult" && impliedAges.has("adult")) {
+            return false;
+          }
+          if (subItem.name === "is_child" && impliedAges.has("child")) {
+            return false;
+          }
+          return true;
+        });
+
+        if (filteredSubItems.length === 0) {
+          // Compound fully satisfied
+          return null;
+        }
+        if (filteredSubItems.length === 1 && !item.nestedOr) {
+          // Single item, no compound needed
+          return filteredSubItems[0];
+        }
+
+        // Rebuild compound with filtered items
+        const rebuilt = {
+          ...item,
+          subItems: filteredSubItems,
+          displayName: filteredSubItems.map(i => i.displayName).join(" and "),
+          name: filteredSubItems.map(i => i.name).sort().join("+"),
+          owned: filteredSubItems.every(si => si.owned),
+        };
+        if (item.nestedOr) {
+          rebuilt.nestedOr = item.nestedOr;
+          const nestedOrDisplay = item.nestedOr.map(n =>
+            n.isCompound ? `(${n.displayName})` : n.displayName
+          ).join(" or ");
+          rebuilt.displayName = `${rebuilt.displayName} and (${nestedOrDisplay})`;
+          rebuilt.name = `${rebuilt.name}+(${item.nestedOr.map(n => n.name).sort().join("|")})`;
+          rebuilt.owned = rebuilt.owned && item.nestedOr.some(n => n.owned);
+        }
+
+        return rebuilt;
+      }
+
+      return item;
+    }).filter(item => item !== null)
+  })).filter(clause => clause.items.length > 0);
+
+  // Then, re-locate age-only clauses in simplifiedClauses (indices may have shifted due to filtering above)
+  // and remove those whose age is implied by other items.
+  const indicesToRemove = new Set();
+  simplifiedClauses.forEach((clause, index) => {
+    if (clause.items.length === 1) {
+      const ageItem = clause.items[0];
+      if (ageItem.name === "is_adult" || ageItem.name === "is_child") {
+        const age = ageItem.name === "is_adult" ? "adult" : "child";
+        if (impliedAges.has(age)) {
+          indicesToRemove.add(index);
+        }
+      }
+    }
+  });
+
+  if (indicesToRemove.size > 0) {
+    return simplifiedClauses.filter((_, index) => !indicesToRemove.has(index));
+  }
+
+  return simplifiedClauses;
+}
+
+/**
+ * Check if a key/rupee item is removed via its shuffle setting.
+ * @param {string} itemName - The logic item name to check.
+ * @returns {boolean} True if the item is removed by the current shuffle setting.
+ */
+function isKeysyRemoved(itemName) {
+  const settings = getSettings();
+  for (const rule of KEY_SHUFFLE_RULES) {
+    if (rule.exact ? itemName === rule.prefix : itemName.startsWith(rule.prefix)) {
+      return settings[rule.setting] === "remove";
+    }
+  }
+  return false;
+}
+
+/**
+ * Return vanilla placement info for an item name given current settings.
+ * @param {string} itemName - The logic item name to check.
+ * @param {object} settings - The current parsed settings object.
+ * @returns {{ isVanilla: boolean, vanillaItemName: string|null }} Placement details.
+ */
+function getVanillaPlacementInfo(itemName, settings) {
+  if (!itemName || !settings) { return { isVanilla: false, vanillaItemName: null }; }
+
+  for (const rule of KEY_SHUFFLE_RULES) {
+    if (rule.exact ? itemName === rule.prefix : itemName.startsWith(rule.prefix)) {
+      const vanillaItemName = rule.vanillaLabel || deriveVanillaItemName(itemName, rule.prefix);
+      return { isVanilla: settings[rule.setting] === "vanilla", vanillaItemName };
+    }
+  }
+  return { isVanilla: false, vanillaItemName: null };
+}
+
+/**
+ * Derive a vanilla item name like "Small Key (Forest Temple)" from "Small_Key_Forest_Temple".
+ * @param {string} itemName - The logic item name to convert.
+ * @param {string} prefix - The matched prefix from KEY_SHUFFLE_RULES.
+ * @returns {string} The human-readable vanilla item name.
+ */
+function deriveVanillaItemName(itemName, prefix) {
+  const category = prefix.replace(/_$/, "").replace(/_/g, " ");
+  const specific = itemName.slice(prefix.length).replace(/_/g, " ");
+  return `${category} (${specific})`;
+}
+
+/**
+ * Detect whether an AST rule node carries an explicit age requirement.
+ * @param {object} node - The parsed AST node to inspect.
+ * @returns {string|null} "adult", "child", or null if no age constraint is detected.
+ */
+function detectAgeRequirement(node) {
+  if (!node) { return null; }
+
+  switch (node.type) {
+    case "ExpressionStatement":
+      return detectAgeRequirement(node.expression);
+
+    case "Identifier":
+      if (node.name === "is_adult") { return "adult"; }
+      if (node.name === "is_child") { return "child"; }
+      return null;
+
+    case "LogicalExpression":
+      if (node.operator === "&&") {
+        // AND: if either side requires an age, that's the requirement
+        const leftAge = detectAgeRequirement(node.left);
+        if (leftAge) { return leftAge; }
+        return detectAgeRequirement(node.right);
+      }
+
+      // OR: only if both sides require the same age
+      // (mixed age OR means either age works, so no restriction)
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Detect if a rule contains here(can_plant_bean).
+ * 
+ * This is important because bean planting requires child access, even if the overall location is adult-only.
+ * @param {object} node - The AST node to inspect.
+ * @returns {boolean} True if the node contains a here(can_plant_bean) call.
+ */
+function containsBeanPlanting(node) {
+  if (!node) { return false; }
+
+  switch (node.type) {
+    case "ExpressionStatement":
+      return containsBeanPlanting(node.expression);
+
+    case "CallExpression":
+      if (node.callee.name === "here" && node.arguments.length > 0) {
+        const arg = node.arguments[0];
+        // Check if argument is can_plant_bean identifier
+        if (arg.type === "Identifier" && arg.name === "can_plant_bean") {
+          return true;
+        }
+
+        // Recursively check the argument
+        return containsBeanPlanting(arg);
+      }
+      // Check arguments of other calls
+      return node.arguments?.some(arg => containsBeanPlanting(arg)) || false;
+
+    case "LogicalExpression":
+      return containsBeanPlanting(node.left) || containsBeanPlanting(node.right);
+
+    case "UnaryExpression":
+      return containsBeanPlanting(node.argument);
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Return the age implied by an item that is exclusively usable by one age.
+ * @param {string} itemName - The logic item name to check.
+ * @returns {string|null} "adult", "child", or null if the item has no age restriction.
+ */
+function getItemImpliedAge(itemName) {
+  const baseName = itemName.split(",")[0];
+  if (ADULT_ONLY_ITEMS.has(baseName)) {
+    return "adult";
+  }
+  if (CHILD_ONLY_ITEMS.has(baseName)) {
+    return "child";
+  }
+  return null;
+}
+
+/**
+ * Return the current settings, preferring the evaluation-scoped cache over a fresh lookup.
+ * @returns {object} The current parsed settings object.
+ */
+function getSettings() {
+  return cachedSettings || LogicHelper.settings;
+}
+
+/**
+ * Return true if the player owns the specified item or meets the required count.
+ * @param {string} itemName - The logic item name, optionally with a count suffix.
+ * @param {object} items - The current tracked items object mapping name to count.
+ * @returns {boolean} True if the ownership requirement is met.
+ */
+function isItemOwned(itemName, items) {
+  if (itemName.includes(",")) {
+    const match = itemName.match(/^(.+),\s*(\d+)$/);
+    if (match) {
+      const name = match[1].trim();
+      const count = parseInt(match[2], 10);
+
+      // Category-based counts (from has_medallions, has_stones, etc.)
+      if (name in CATEGORY_ITEMS) {
+        const ownedCount = CATEGORY_ITEMS[name].filter(item => (items[item] || 0) > 0).length;
+        return ownedCount >= count;
+      }
+      if (name === "Hearts") {
+        const pieces = items.Piece_of_Heart || 0;
+        const containers = items.Heart_Container || 0;
+        const totalHearts = Math.floor(pieces / 4) + containers + 3;
+        return totalHearts >= count;
+      }
+
+      return (items[name] || 0) >= count;
+    }
+  }
+
+  // Check if player has the item in their inventory
+  if ((items[itemName] || 0) > 0) {
+    return true;
+  }
+
+  // Check if it's a starting item from settings (inventory or equipment)
+  const startingItems = LogicHelper.getStartingItems();
+  if ((startingItems[itemName] || 0) > 0) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Return true if the identifier refers to a settings flag rather than a collectible item.
+ * @param {string} name - The identifier name from the logic AST.
+ * @returns {boolean} True if the name is a settings or renamed-attributes key.
+ */
+function isSettingsIdentifier(name) {
+  const settings = getSettings();
+  const renamedAttributes = LogicHelper.renamedAttributes;
+
+  if (name in settings || name in renamedAttributes) {
+    return true;
+  }
+
+  for (const prefix of SETTINGS_PREFIXES) {
+    if (name.startsWith(prefix)) {
+      return true;
+    }
+  }
+
+  // Identifier should be displayed, not evaluated
+  return false;
+}
+
+/**
+ * Shared expansion logic for events and drops.
+ * 
+ * Each source's rule is extracted, AND-merged with its region access requirements, and the resulting expressions are
+ * OR-combined.
+ * @param {string} type - Cache key prefix ("event" or "drop").
+ * @param {string} name - The event or drop name.
+ * @param {Array} sources - Array of { rule, parentRegion } objects.
+ * @param {object} items - Current tracked items.
+ * @param {Set} visited - Visited set for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @param {boolean} skipUnreachableRegions - If true, skip sources in regions not found in the region cache.
+ *  Events use true (unreachable = skip); drops use false.
+ * @returns {Expression} The OR combination of all source expressions.
+ */
+function expandSources(type, name, sources, items, visited, depth, skipUnreachableRegions) {
+  const cacheKey = `${type}:${name}`;
+  if (visited.has(cacheKey)) { return impossibleExpr(); }
+  if (evaluationCache?.has(cacheKey)) { return evaluationCache.get(cacheKey).clone(); }
+  if (!sources || sources.length === 0) { return impossibleExpr(); }
+
+  visited.add(cacheKey);
+  const sourceExprs = [];
+
+  for (const source of sources) {
+    const { rule, parentRegion } = source;
+    if (!rule) { continue; }
+
+    const ruleExpr = extractFromNode(rule, items, visited, depth + 1);
+    if (ruleExpr.isImpossible()) { continue; }
+
+    // AND-merge region access requirements (only when a region cache is active)
+    const activeCache = getActiveRegionCache();
+    if (activeCache) {
+      if (activeCache.has(parentRegion)) {
+        const regionExpr = activeCache.get(parentRegion).clone();
+        if (!regionExpr.isEmpty() && !regionExpr.isSatisfied()) {
+          ruleExpr.merge(regionExpr);
+          ruleExpr.simplify();
+          if (ruleExpr.isImpossible()) { continue; }
+        }
+      } else if (skipUnreachableRegions && !ENTRY_POINT_REGIONS.has(parentRegion)) {
+        continue;
+      }
+    }
+
+    sourceExprs.push(ruleExpr);
+  }
+
+  visited.delete(cacheKey);
+
+  const result = combineWithOr(sourceExprs);
+  if (evaluationCache) { evaluationCache.set(cacheKey, result); }
+  return result.clone();
+}
+
+/**
+ * Expand an event into its requisite item requirements.
+ * Events can have multiple sources (different regions/rules that trigger them).  Multiple sources are combined with OR.
+ *
+ * Dungeon clear and boss defeat events are treated as impossible to force simpler OR branches, since computing full
+ * dungeon paths exceeds BFS capabilities. Exception: Trial Clear events are needed for Ganon's Tower access.
+ * @param {string} eventName - The event name to expand.
+ * @param {object} items - Current tracked items.
+ * @param {Set} visited - Visited set for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @returns {Expression} The item requirements to trigger this event.
+ */
+function expandEvent(eventName, items, visited, depth) {
+  const isTrialClear = eventName.endsWith(" Trial Clear");
+  if ((eventName.endsWith(" Clear") && !isTrialClear) || eventName.startsWith("Defeat ")) {
+    return impossibleExpr();
+  }
+  return expandSources("event", eventName, Locations.getEvent(eventName), items, visited, depth, true);
+}
+
+/**
+ * Expand a drop item into its access requirements.
+ * 
+ * Unlike events, drops in dungeon-interior regions (not in the region cache) are still included, as their rule
+ * requirements are meaningful for tooltips.
+ * @param {string} dropName - The drop name to expand.
+ * @param {object} items - Current tracked items.
+ * @param {Set} visited - Visited set for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @returns {Expression} The access requirements for this drop.
+ */
+function expandDrop(dropName, items, visited, depth) {
+  return expandSources("drop", dropName, Locations.getDropLocations(dropName), items, visited, depth, false);
+}
+
+/**
+ * Expand a persistent event/location while skipping age requirements.
+ * Includes both the rule requirements AND region access requirements.
+ * Used for persistent events where age is about WHEN to trigger (player can time travel).
+ *
+ * Checks both events and locations since some "events" like "Deliver Rutos Letter"
+ * are stored as locations in the logic files.
+ * @param {string} eventName - The event/location name (e.g., "Deliver Rutos Letter").
+ * @param {object} items - Current tracked items.
+ * @param {Set} visited - Visited set for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @returns {Expression} Combined event + region access requirements.
+ */
+function expandEventSkippingAge(eventName, items, visited, depth) {
+  const visitKey = `persistent_event:${eventName}`;
+  if (visited.has(visitKey)) {
+    return impossibleExpr();
+  }
+
+  // Also check if the flag this event produces is already being evaluated
+  const producedFlags = EVENT_TO_FLAG[eventName] || [];
+  for (const flag of producedFlags) {
+    if (visited.has(flag) || visited.has(`persistent_event:${flag}`)) {
+      return impossibleExpr();
+    }
+  }
+
+  // Try events first
+  let eventData = Locations.getEvent(eventName);
+
+  // If not found as event, try as a location
+  if (!eventData || eventData.length === 0) {
+    const locationData = Locations.getLocation(eventName);
+    if (locationData && locationData.rule) {
+      eventData = [{
+        rule: locationData.rule,
+        parentRegion: locationData.parentRegion,
+      }];
+    }
+  }
+
+  if (!eventData || eventData.length === 0) {
+    return impossibleExpr();
+  }
+
+  visited.add(visitKey);
+
+  // Also mark the produced flags as visited to prevent circular references
+  for (const flag of producedFlags) {
+    visited.add(flag);
+  }
+
+  const sourceExprs = [];
+
+  for (const source of eventData) {
+    const { rule, parentRegion } = source;
+    if (!rule) { continue; }
+
+    // Evaluate per-age: persistent events can only be triggered by one age, and the region access requirements must
+    // match that age. Evaluating per-age correctly filters.
+    const ages = [["child", regionCacheChild], ["adult", regionCacheAdult]];
+
+    for (const [age, cache] of ages) {
+      const savedAge = currentAgeContext;
+      const savedEvalCache = evaluationCache;
+      currentAgeContext = age;
+      evaluationCache = new Map();
+
+      const ruleExpr = extractFromNode(rule, items, visited, depth + 1);
+      currentAgeContext = savedAge;
+      evaluationCache = savedEvalCache;
+
+      if (ruleExpr.isImpossible()) { continue; }
+
+      // Look up region requirements from this age's cache
+      let regionExpr;
+      if (cache?.has(parentRegion)) {
+        regionExpr = cache.get(parentRegion).clone();
+      } else if (ENTRY_POINT_REGIONS.has(parentRegion)) {
+        regionExpr = new Expression();
+      } else if (!cache) {
+        // This age's cache is being built or not yet built, so treat region as reachable
+        regionExpr = new Expression();
+      } else {
+        // Region unreachable at this age
+        continue;
+      }
+
+      const combined = ruleExpr.clone();
+      if (!regionExpr.isEmpty() && !regionExpr.isImpossible()) {
+        combined.merge(regionExpr);
+      }
+
+      if (!combined.isImpossible()) {
+        sourceExprs.push(combined);
+      }
+    }
+  }
+
+  visited.delete(visitKey);
+
+  // Clean up the produced flags from visited
+  for (const flag of producedFlags) {
+    visited.delete(flag);
+  }
+
+  if (sourceExprs.length === 0) {
+    return impossibleExpr();
+  }
+
+  // Combine all sources with OR
+  let result = sourceExprs[0];
+  for (let i = 1; i < sourceExprs.length; i++) {
+    result = orCombineExpressions(result, sourceExprs[i]);
+  }
+  return result;
+}
+
+/**
+ * Expand has_bottle into actual bottle item requirements.
+ * @param {object} items - Current tracked items.
+ * @param {Set} visited - Visited set for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @returns {Expression} The expanded bottle options as an OR clause.
+ */
+function expandHasBottle(items, visited = new Set(), depth = 0) {
+  const settings = getSettings();
+  const bottleOwned = isItemOwned("Bottle", items);
+  let result = new Expression([
+    new Clause([new RequirementItem("Bottle", "Bottle", bottleOwned)]),
+  ]);
+
+  // Bottle with Big Poe can be emptied by selling to the Poe Collector
+  const bigPoeOwned = isItemOwned("Bottle_with_Big_Poe", items);
+  result = orCombineExpressions(
+    result,
+    new Expression([new Clause([new RequirementItem("Bottle_with_Big_Poe", "Bottle with Big Poe", bigPoeOwned)])]),
+  );
+
+  // Deliver Ruto's Letter produces a usable bottle
+  if (settings?.zora_fountain !== "open") {
+    const deliverExpr = expandEventSkippingAge("Deliver Rutos Letter", items, visited, depth + 1);
+    if (!deliverExpr.isImpossible() && !deliverExpr.isEmpty()) {
+      result = orCombineExpressions(result, deliverExpr);
+    }
+  }
+  return result;
+}
+
+/**
+ * Recursively extract item requirements from an AST node.
+ *
+ * Dispatches to the appropriate handler based on node type.
+ * @param {object} node - The parsed AST node to extract from.
+ * @param {object} items - The current tracked items object.
+ * @param {Set} visited - Visited identifiers/events for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @param {boolean} skipAgeFiltering - When true, treat age requirements as satisfied.
+ * @returns {Expression} The extracted requirements.
+ */
+function extractFromNode(node, items, visited = new Set(), depth = 0, skipAgeFiltering = false) {
+  // Maximum recursion depth to prevent infinite loops
+  // But, needs to be high enough for deeply nested type-checks
+  if (!node || depth > 25) {
+    return new Expression();
+  }
+
+  switch (node.type) {
+    case "ExpressionStatement":
+      return extractFromNode(node.expression, items, visited, depth, skipAgeFiltering);
+
+    case "Literal":
+      return handleLiteral(node.value, items, visited, depth);
+
+    case "Identifier":
+      return handleIdentifier(node.name, items, visited, depth, skipAgeFiltering);
+
+    case "LogicalExpression":
+      return handleLogicalExpression(node, items, visited, depth, skipAgeFiltering);
+
+    case "BinaryExpression":
+      return handleBinaryExpression(node);
+
+    case "CallExpression":
+      return handleCallExpression(node, items, visited, depth, skipAgeFiltering);
+
+    case "SequenceExpression":
+      return handleSequenceExpression(node, items, visited, depth, skipAgeFiltering);
+
+    case "UnaryExpression":
+      return handleUnaryExpression(node);
+
+    case "MemberExpression":
+      return handleMemberExpression(node);
+
+    default:
+      return new Expression();
+  }
+}
+
+/**
+ * Handle a binary expression AST node.
+ * @param {object} node - The BinaryExpression AST node.
+ * @returns {Expression} Satisfied Expression if condition is true, impossible otherwise.
+ */
+function handleBinaryExpression(node) {
+  const isEquality = node.operator === "==" || node.operator === "===";
+  const isInequality = node.operator === "!=" || node.operator === "!==";
+
+  if (isEquality || isInequality) {
+    const leftName = node.left.type === "Identifier" ? node.left.name : null;
+    const rightName = node.right.type === "Identifier" ? node.right.name : null;
+    const leftLiteral = node.left.type === "Literal" ? node.left.value : null;
+    const rightLiteral = node.right.type === "Literal" ? node.right.value : null;
+
+    // Identifier == Identifier (same name comparison)
+    if (leftName && rightName) {
+      const same = leftName === rightName;
+      const matches = isEquality ? same : !same;
+      if (matches) {
+        return new Expression();
+      } else {
+        return impossibleExpr();
+      }
+    }
+
+    // Identifier == Literal (setting comparison)
+    if (leftName && rightLiteral !== null) {
+      const settings = getSettings();
+      const settingValue = settings?.[leftName];
+      if (settingValue !== undefined) {
+        const matches = isEquality ? settingValue === rightLiteral : settingValue !== rightLiteral;
+        if (matches) {
+          return new Expression();
+        } else {
+          return impossibleExpr();
+        }
+      }
+    }
+
+    // Literal == Identifier (reverse setting comparison)
+    if (leftLiteral !== null && rightName) {
+      const settings = getSettings();
+      const settingValue = settings?.[rightName];
+      if (settingValue !== undefined) {
+        const matches = isEquality ? leftLiteral === settingValue : leftLiteral !== settingValue;
+        if (matches) {
+          return new Expression();
+        } else {
+          return impossibleExpr();
+        }
+      }
+    }
+  }
+
+  // For other binary expressions or unrecognized patterns, return impossible
+  return impossibleExpr();
+}
+
+/**
+ * Handle a call expression AST node.
+ * @param {object} node - The CallExpression AST node.
+ * @param {object} items - The current tracked items object.
+ * @param {Set} visited - Visited identifiers/events for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @param {boolean} skipAgeFiltering - When true, treat age requirements as satisfied.
+ * @returns {Expression} The extracted requirements for this call.
+ */
+function handleCallExpression(node, items, visited, depth, skipAgeFiltering = false) {
+  const funcName = node.callee.name;
+
+  if (funcName === "here") {
+    if (node.arguments.length > 0) {
+      // Bean planting via here(can_plant_bean) is a persistent world change.
+      // Skip age filtering so the bean requirement appears in any age context.
+      const arg = node.arguments[0];
+      const isBeanPlanting = arg.type === "Identifier" && arg.name === "can_plant_bean";
+      const beanExpr = extractFromNode(arg, items, visited, depth + 1, isBeanPlanting || skipAgeFiltering);
+
+      // In age-specific context, child must reach this region to plant the bean.
+      // Merge child region access into just the bean sub-expression so non-bean OR branches keep the age-specific
+      // region access.
+      if (isBeanPlanting && beanPlantingChildRegionExpr) {
+        beanExpr.merge(beanPlantingChildRegionExpr.clone());
+        beanExpr.simplify();
+      }
+
+      return beanExpr;
+    }
+    return new Expression();
+  }
+
+  if (funcName === "at") {
+    if (node.arguments.length >= 2) {
+      const ruleExpr = extractFromNode(node.arguments[1], items, visited, depth + 1, skipAgeFiltering);
+
+      // AND-merge region access requirements
+      // During BFS, use the previous iteration's snapshot to prevent cyclic feedback
+      const regionName = node.arguments[0]?.value;
+      const lookupCache = bfsAtLookupCache || getActiveRegionCache();
+      if (regionName && lookupCache) {
+        if (lookupCache.has(regionName)) {
+          const regionExpr = lookupCache.get(regionName).clone();
+          if (!regionExpr.isEmpty() && !regionExpr.isSatisfied()) {
+            ruleExpr.merge(regionExpr);
+            ruleExpr.simplify();
+          }
+        } else if (!ENTRY_POINT_REGIONS.has(regionName)) {
+          return impossibleExpr();
+        }
+      }
+      return ruleExpr;
+    }
+
+    return new Expression();
+  }
+
+  // Handle built-in reward/heart counting functions
+  const rewardFuncs = {
+    has_medallions: GAME_REWARDS.medallions,
+    has_stones: GAME_REWARDS.stones,
+    has_dungeon_rewards: GAME_REWARDS.dungeonRewards,
+  };
+  if (funcName in rewardFuncs || funcName === "has_hearts") {
+    const countArg = node.arguments[0];
+    const settings = getSettings();
+    const requiredCount = countArg.type === "Identifier" ? (settings[countArg.name] || 0) : countArg.value;
+
+    if (requiredCount <= 0) { return new Expression(); }
+
+    if (funcName === "has_hearts") {
+      const displayName = `Hearts x${requiredCount}`;
+      return new Expression([new Clause([new RequirementItem(`Hearts,${requiredCount}`, displayName, false)])]);
+    }
+
+    const itemList = rewardFuncs[funcName];
+    if (requiredCount >= itemList.length) {
+      // All items required
+      const clauses = itemList.map(item => {
+        const owned = (items[item] || 0) > 0;
+        return new Clause([new RequirementItem(item, getDisplayName(item), owned)]);
+      });
+      return new Expression(clauses);
+    }
+
+    // Partial count
+    const categoryName = funcName === "has_medallions" ? "Medallions"
+      : funcName === "has_stones" ? "Stones"
+        : "Dungeon Rewards";
+    const displayName = `${categoryName} x${requiredCount}`;
+    const ownedCount = itemList.filter(item => (items[item] || 0) > 0).length;
+    const owned = ownedCount >= requiredCount;
+
+    return new Expression([new Clause([new RequirementItem(`${categoryName},${requiredCount}`, displayName, owned)])]);
+  }
+
+  const paramAliases = LogicHelper.parameterizedAliases;
+  if (funcName in paramAliases) {
+    const { patterns, template } = paramAliases[funcName];
+
+    const argValues = node.arguments.map(arg => {
+      if (arg.type === "Identifier") {
+        return arg.name;
+      }
+      if (arg.type === "Literal") {
+        return String(arg.value);
+      }
+      return "";
+    });
+
+    // Substitute parameters
+    let substituted = template;
+    patterns.forEach((pattern, i) => {
+      substituted = substituted.replace(pattern, argValues[i]);
+    });
+
+    // Parse and extract from substituted rule
+    const visitKey = `${funcName}(${argValues.join(",")})`;
+    if (!visited.has(visitKey)) {
+      visited.add(visitKey);
+      const parsedRule = parseRule(substituted);
+      const expanded = extractFromNode(parsedRule, items, visited, depth + 1, skipAgeFiltering);
+      visited.delete(visitKey);
+      return expanded;
+    }
+  }
+
+  return new Expression();
+}
+
+/**
+ * Handle an identifier AST node by resolving it to an Expression.
+ * @param {string} name - The identifier name from the AST.
+ * @param {object} items - The current tracked items object.
+ * @param {Set} visited - Visited identifiers/events for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @param {boolean} skipAgeFiltering - When true, treat age requirements as satisfied.
+ * @returns {Expression} The requirements associated with this identifier.
+ */
+function handleIdentifier(name, items, visited, depth, skipAgeFiltering = false) {
+  // Age requirements
+  if (name === "is_adult") {
+    if (skipAgeFiltering) {
+      return new Expression();
+    }
+    const settings = getSettings();
+    const randomAge = settings?.starting_age === "random";
+
+    if (currentAgeContext === "child") {
+      // Location requires child, but this path requires adult
+      return impossibleExpr();
+    }
+
+    if (currentAgeContext === "adult" || randomAge) {
+      // Either already in adult context or can start as adult
+      return new Expression();
+    }
+
+    return new Expression([new Clause([new RequirementItem("is_adult", "Adult", false, true)])]);
+  }
+
+  if (name === "is_child") {
+    if (skipAgeFiltering) {
+      return new Expression();
+    }
+    const settings = getSettings();
+    const randomAge = settings?.starting_age === "random";
+
+    if (currentAgeContext === "adult") {
+      // Location requires adult, but this path requires child
+      return impossibleExpr();
+    }
+    if (currentAgeContext === "child" || randomAge) {
+      // Either already in child context or can start as child
+      return new Expression();
+    }
+
+    return new Expression([new Clause([new RequirementItem("is_child", "Child", false, true)])]);
+  }
+
+  // Auto-satisfied identifiers
+  if (SKIP_IDENTIFIERS.has(name)) {
+    return new Expression();
+  }
+
+  // Ocarina notes
+  if (OCARINA_NOTE_IDENTIFIERS.has(name)) {
+    const settings = getSettings();
+    if (!settings.shuffle_individual_ocarina_notes) {
+      return new Expression();
+    }
+  }
+
+  // Buy_ items with wallet and/or bottle requirements
+  const shopReq = SHOP_WALLET_REQUIREMENTS.get(name);
+  const needsBottle = SHOP_BOTTLE_REQUIRED.has(name);
+  if (shopReq || needsBottle) {
+    let result = new Expression();
+
+    if (shopReq) {
+      const walletOwned = isItemOwned(shopReq.id, items);
+      result = new Expression([new Clause([new RequirementItem(shopReq.id, shopReq.label, walletOwned)])]);
+    }
+
+    if (needsBottle) {
+      const bottleExpr = expandHasBottle(items, visited, depth + 1);
+      result.merge(bottleExpr);
+      result.simplify();
+    }
+
+    return result;
+  }
+
+  // Skip identifiers with certain prefixes
+  for (const prefix of SKIP_PREFIXES) {
+    if (name.startsWith(prefix)) {
+      return new Expression();
+    }
+  }
+
+  // Settings evaluation
+  if (isSettingsIdentifier(name)) {
+    const settings = getSettings();
+    const renamedAttributes = LogicHelper.renamedAttributes;
+    let settingValue = false;
+
+    if (name.startsWith("logic_")) {
+      settingValue = SettingsHelper.isAllowedTrick(name);
+    }
+    else if (name.startsWith("adv_") || name.startsWith("glitch_")) {
+      settingValue = SettingsHelper.isAdvancedAllowedTrick(name);
+    }
+    else if (name.startsWith("at_")) {
+      settingValue = true;
+    }
+    else if (name in settings) {
+      settingValue = settings[name];
+    }
+    else if (name in renamedAttributes) {
+      settingValue = renamedAttributes[name];
+    }
+
+    if (settingValue) {
+      return new Expression();
+    } else {
+      return impossibleExpr();
+    }
+  }
+
+  // Recursive expansion
+  if (name === "has_bottle") {
+    return expandHasBottle(items, visited, depth);
+  }
+
+  // Check if this identifier is already being expanded
+  if (visited.has(name)) {
+    return impossibleExpr();
+  }
+
+  // Expand events into item requirements
+  const escapedName = name.replace(/_/g, " ");
+  if (Locations.hasEvent(escapedName)) {
+    return expandEvent(escapedName, items, visited, depth);
+  }
+
+  // Check if this is an event flag that maps to a different source event/location
+  if (escapedName in FLAG_TO_EVENT) {
+    return expandEventSkippingAge(FLAG_TO_EVENT[escapedName], items, visited, depth);
+  }
+
+  // If it's a rule alias, expand it
+  const ruleAliases = LogicHelper.ruleAliases;
+  if (name in ruleAliases) {
+    // Cache key includes skipAgeFiltering to avoid mixing results
+    const aliasCacheKey = skipAgeFiltering ? `alias_noage:${name}` : `alias:${name}`;
+    if (evaluationCache?.has(aliasCacheKey)) {
+      return evaluationCache.get(aliasCacheKey).clone();
+    }
+
+    visited.add(name);
+    const expanded = extractFromNode(ruleAliases[name], items, visited, depth + 1, skipAgeFiltering);
+    visited.delete(name);
+
+    if (evaluationCache) {
+      evaluationCache.set(aliasCacheKey, expanded);
+    }
+    return expanded.clone();
+  }
+
+  // Expand drops into access requirements
+  if (Locations.hasDrop(escapedName)) {
+    return expandDrop(escapedName, items, visited, depth);
+  }
+
+  // Terminal item handling
+  if (isKeysyRemoved(name)) {
+    return new Expression();
+  }
+
+  // Default: create a clause with this item as a requirement
+  const owned = isItemOwned(name, items);
+  const clause = new Clause([new RequirementItem(name, getDisplayName(name), owned)]);
+  return new Expression([clause]);
+}
+
+/**
+ * Handle a literal AST node.
+ * @param {string|boolean|null} value - The literal value from the AST node.
+ * @param {object} items - The current tracked items object.
+ * @param {Set} visited - Visited identifiers/events for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @returns {Expression} The requirements for this literal value.
+ */
+function handleLiteral(value, items, visited, depth) {
+  // Boolean true/null
+  if (value === true || value === null) {
+    return new Expression();
+  }
+
+  // Expand events into item requirements
+  if (Locations.hasEvent(value)) {
+    return expandEvent(value, items, visited, depth);
+  }
+
+  // Expand drops into access requirements.
+  if (Locations.hasDrop(value)) {
+    if (regionCacheBuildingMode && !NON_FREE_DROPS.has(value)) {
+      return new Expression(); // Auto-satisfy free drops during cache building
+    }
+    return expandDrop(value, items, visited, depth);
+  }
+
+  // Check if it's a findable item
+  const itemId = STRING_LITERAL_ITEMS[value];
+  if (itemId) {
+    const owned = isItemOwned(itemId, items);
+    const displayName = getDisplayName(itemId);
+    return new Expression([new Clause([new RequirementItem(itemId, displayName, owned)])]);
+  }
+
+  // Unknown literal
+  return impossibleExpr();
+}
+
+/**
+ * Handle a logical expression AST node.
+ * @param {object} node - The LogicalExpression AST node.
+ * @param {object} items - The current tracked items object.
+ * @param {Set} visited - Visited identifiers/events for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @param {boolean} skipAgeFiltering - When true, treat age requirements as satisfied.
+ * @returns {Expression} The combined requirements for this logical expression.
+ */
+function handleLogicalExpression(node, items, visited, depth, skipAgeFiltering = false) {
+  const leftExpr = extractFromNode(node.left, items, visited, depth + 1, skipAgeFiltering);
+  const rightExpr = extractFromNode(node.right, items, visited, depth + 1, skipAgeFiltering);
+
+  if (node.operator === "&&") {
+    leftExpr.merge(rightExpr);
+    // Clear vanilla flag after merge
+    if (!leftExpr.isEmpty()) {
+      leftExpr.vanillaAutoSatisfied = false;
+    }
+    return leftExpr;
+  } else if (node.operator === "||") {
+    // Vanilla auto-satisfied items
+    if (leftExpr.vanillaAutoSatisfied) {
+      return rightExpr.isImpossible() ? new Expression() : rightExpr;
+    }
+    if (rightExpr.vanillaAutoSatisfied) {
+      return leftExpr.isImpossible() ? new Expression() : leftExpr;
+    }
+
+    if (leftExpr.isEmpty() || leftExpr.isSatisfied()) {
+      return new Expression();
+    }
+    if (rightExpr.isEmpty() || rightExpr.isSatisfied()) {
+      return new Expression();
+    }
+
+    // If one side is impossible, use the other side instead of merging
+    if (leftExpr.isImpossible()) {
+      return rightExpr;
+    }
+    if (rightExpr.isImpossible()) {
+      return leftExpr;
+    }
+
+    return orCombineExpressions(leftExpr, rightExpr);
+  }
+
+  return leftExpr;
+}
+
+/**
+ * Handle a sequence expression AST node.
+ * @param {object} node - The SequenceExpression AST node.
+ * @param {object} items - The current tracked items object.
+ * @param {Set} visited - Visited identifiers/events for cycle detection.
+ * @param {number} depth - Current recursion depth.
+ * @param {boolean} skipAgeFiltering - When true, treat age requirements as satisfied.
+ * @returns {Expression} The requirements for this counted item.
+ */
+function handleSequenceExpression(node, items, visited, depth, skipAgeFiltering = false) {
+  if (node.expressions.length !== 2) {
+    return new Expression();
+  }
+
+  const itemName = node.expressions[0].name;
+  const countNode = node.expressions[1];
+  const settings = getSettings();
+  const count = countNode.type === "Identifier" ? (settings[countNode.name] || 0) : countNode.value;
+
+  // Check for keysy modes
+  if (isKeysyRemoved(itemName)) {
+    return new Expression();
+  }
+
+  // Check for vanilla placement
+  const vanillaInfo = getVanillaPlacementInfo(itemName, settings);
+  if (vanillaInfo.isVanilla && vanillaInfo.vanillaItemName) {
+    // If we're already tracing this item, skip to avoid infinite recursion
+    if (visited.has(itemName)) {
+      return new Expression();
+    }
+
+    // Find vanilla locations for this item
+    const vanillaLocations = Locations.getLocationsByVanillaItem(vanillaInfo.vanillaItemName);
+    if (vanillaLocations.length > 0) {
+      const newVisited = new Set(visited);
+      newVisited.add(itemName);
+
+      // Find a representative location and prefer one with a non-trivial rule
+      let bestLocation = null;
+      let bestIsTrivial = true;
+      for (const vanillaLocation of vanillaLocations) {
+        if (!vanillaLocation.rule) { continue; }
+        const ruleAst = vanillaLocation.rule.expression || vanillaLocation.rule;
+        const isTrivial = ruleAst.type === "Identifier" && ruleAst.name === "True";
+        if (!bestLocation) {
+          bestLocation = vanillaLocation;
+          bestIsTrivial = isTrivial;
+        }
+        if (!isTrivial) {
+          bestLocation = vanillaLocation;
+          bestIsTrivial = isTrivial;
+          break;
+        }
+      }
+
+      if (bestLocation) {
+        const isTrivial = bestIsTrivial;
+
+        // During BFS, only evaluate the location rule to avoid circular dependencies
+        if (regionCacheBuildingMode) {
+          const bfsExpr = isTrivial
+            ? new Expression()
+            : extractFromNode(bestLocation.rule, items, newVisited, depth + 1, skipAgeFiltering);
+
+          // Flag trivial vanilla items so they don't short-circuit OR clauses
+          if (isTrivial) { bfsExpr.vanillaAutoSatisfied = true; }
+          return bfsExpr;
+        }
+
+        // Evaluate rule and merge region access requirements
+        const locExpr = isTrivial
+          ? new Expression()
+          : extractFromNode(bestLocation.rule, items, newVisited, depth + 1, skipAgeFiltering);
+        if (isTrivial) { locExpr.vanillaAutoSatisfied = true; }
+
+        if (!locExpr.isImpossible() && bestLocation.parentRegion && !bestLocation.isDungeon) {
+          const activeCache = getActiveRegionCache();
+          if (activeCache && activeCache.has(bestLocation.parentRegion)) {
+            const regionExpr = activeCache.get(bestLocation.parentRegion).clone();
+            if (!regionExpr.isEmpty() && !regionExpr.isSatisfied()) {
+              locExpr.merge(regionExpr);
+              locExpr.simplify();
+            }
+          }
+        }
+        return locExpr;
+      }
+    }
+
+    // No vanilla location found
+    return new Expression();
+  }
+
+  // Account for removed locked door in Fire Temple when keysanity is off
+  let adjustedCount = count;
+  const renamedAttributes = LogicHelper.renamedAttributes;
+  if (!renamedAttributes.keysanity && itemName === "Small_Key_Fire_Temple") {
+    adjustedCount = count - 1;
+  }
+
+  const owned = (items[itemName] || 0) >= adjustedCount;
+
+  // Format display name with count
+  let displayName = getDisplayName(itemName);
+  if (adjustedCount > 1 && itemName !== "Magic_Bean") {
+    displayName = `${displayName} x${adjustedCount}`;
+  }
+
+  const clause = new Clause([new RequirementItem(`${itemName},${adjustedCount}`, displayName, owned)]);
+  return new Expression([clause]);
+}
+
+/**
+ * Handle a unary expression AST node.
+ * @param {object} node - The UnaryExpression AST node.
+ * @returns {Expression} Impossible Expression if the negated condition is true, satisfied otherwise.
+ */
+function handleUnaryExpression(node) {
+  if (node.operator === "!" && node.argument?.type === "Identifier") {
+    const name = node.argument.name;
+    if (isSettingsIdentifier(name)) {
+      let settingValue = false;
+      if (name.startsWith("at_")) {
+        // at_ identifiers are always true, so !at_x is always false
+        settingValue = true;
+      } else if (name.startsWith("logic_")) {
+        settingValue = SettingsHelper.isAllowedTrick(name);
+      } else if (name.startsWith("adv_") || name.startsWith("glitch_")) {
+        settingValue = SettingsHelper.isAdvancedAllowedTrick(name);
+      } else {
+        const settings = getSettings();
+        const renamedAttributes = LogicHelper.renamedAttributes;
+        if (name in settings) {
+          settingValue = settings[name];
+        } else if (name in renamedAttributes) {
+          settingValue = renamedAttributes[name];
+        }
+      }
+      if (settingValue) {
+        return impossibleExpr();
+      }
+      return new Expression();
+    }
+  }
+
+  // Default: treat as satisfied
+  return new Expression();
+}
+
+/**
+ * Handle a member expression AST node.
+ * @param {object} node - The MemberExpression AST node.
+ * @returns {Expression} The requirements for this member expression.
+ */
+function handleMemberExpression(node) {
+  // Handle skipped_trials[TrialName]
+  if (node.object?.name === "skipped_trials" && node.property) {
+    const settings = getSettings();
+    const trialsRandom = settings.trials_random;
+    const trialsCount = settings.trials;
+
+    // 0 trials, not random: all trials are skipped
+    if (!trialsRandom && trialsCount === 0) {
+      return new Expression();
+    }
+
+    // 6 trials, not random: force trial clear events
+    if (!trialsRandom && trialsCount === 6) {
+      return impossibleExpr();
+    }
+
+    // Partial or random trials: show synthetic "Trials Cleared xN" requirement
+    const label = trialsRandom ? "Trials Cleared" : `Trials Cleared x${trialsCount}`;
+    const id = trialsRandom ? "Trials_Cleared" : `Trials_Cleared,${trialsCount}`;
+    return new Expression([new Clause([new RequirementItem(id, label, false)])]);
+  }
+
+  // Default: treat as satisfied
+  return new Expression();
+}
+
+/**
+ * Build a region accessibility cache via fixed-point forward propagation.
+ * Computes the requirements to reach every region from ENTRY_POINT_REGIONS.
+ *
+ * Uses dual tracking to prevent CNF over-approximation from graph cycles:
+ * - DNF paths (list of item-sets per region) for accurate update decisions
+ * - CNF Expression cache for at()/event lookups during rule evaluation
+ *
+ * Without DNF tracking, iterative OR-combining in cycles creates CNF cross-products
+ * that mix items from independent routes, producing phantom satisfying assignments.
+ * @param {object} items - Current tracked items.
+ * @returns {Map} A map from region name to the CNF Expression required to reach it.
+ */
+function buildRegionCache(items) {
+  const cache = new Map();       // CNF Expression cache (for at() lookups and final output)
+  const dnfCache = new Map();    // DNF paths cache (for accurate BFS updates)
+
+  // 1. Seed entry points
+  for (const entry of ENTRY_POINT_REGIONS) {
+    cache.set(entry, new Expression());
+    dnfCache.set(entry, [[]]);
+  }
+
+  // 2. Collect raw edges
+  const allEdges = [];
+  for (const regionName of Object.keys(Locations.regionMap)) {
+    const exits = Locations.getExitsForRegion(regionName);
+    if (!exits) { continue; }
+    for (const [targetRegion, rule] of Object.entries(exits)) {
+      if (EXCLUDED_FROM_PATHFINDING.has(targetRegion)) { continue; }
+      allEdges.push({ source: regionName, target: targetRegion, rule });
+    }
+  }
+
+  // 3. Fixed-point iteration with in-progress cache visible to expandEvent/expandDrop/at()
+  regionCacheBuildingMode = true;
+  activeRegionCacheOverride = cache;
+
+  let previousCache = new Map(cache);
+
+  let changed = true;
+  let iterations = 0;
+  while (changed && iterations < 20) {
+    changed = false;
+    iterations++;
+    evaluationCache = new Map();
+    bfsAtLookupCache = previousCache;
+
+    for (const { source, target, rule } of allEdges) {
+      if (!dnfCache.has(source)) { continue; }
+
+      // Evaluate exit rule to CNF Expression
+      const exitExpr = extractFromNode(rule, items, new Set(), 0);
+      if (exitExpr.isImpossible()) { continue; }
+
+      // Convert exit CNF to DNF paths and combine with source paths
+      const exitPaths = expressionToDNFPaths(exitExpr);
+      if (exitPaths.length === 0) { continue; }
+
+      const sourcePaths = dnfCache.get(source);
+      const newPaths = combineDNFPaths(sourcePaths, exitPaths);
+
+      if (!dnfCache.has(target)) {
+        const pruned = pruneDominatedDNFPaths(newPaths);
+        dnfCache.set(target, pruned);
+        cache.set(target, dnfPathsToExpression(pruned));
+        changed = true;
+      } else {
+        const existing = dnfCache.get(target);
+        const all = [...existing, ...newPaths];
+        const pruned = pruneDominatedDNFPaths(all);
+
+        if (!dnfPathSetsEqual(pruned, existing)) {
+          dnfCache.set(target, pruned);
+          cache.set(target, dnfPathsToExpression(pruned));
+          changed = true;
+        }
+      }
+    }
+
+    previousCache = new Map(cache);
+  }
+
+  bfsAtLookupCache = null;
+  regionCacheBuildingMode = false;
+  activeRegionCacheOverride = null;
+
+  return cache;
+}
+
+/**
+ * Get the region cache for the current age context.
+ * @returns {Map|null} The active region cache map, or null if none is set.
+ */
+function getActiveRegionCache() {
+  if (activeRegionCacheOverride) { return activeRegionCacheOverride; }
+  if (currentAgeContext === "child") { return regionCacheChild; }
+  if (currentAgeContext === "adult") { return regionCacheAdult; }
+  return null;
+}
+
+/**
+ * Build the region cache for a given age if it doesn't exist yet.
+ *
+ * Saves/restores currentAgeContext and evaluationCache around the build.
+ * @param {string} age - The age context ("child" or "adult").
+ * @param {object} items - Current tracked items.
+ */
+function ensureRegionCache(age, items) {
+  if (age === "child" && regionCacheChild) { return; }
+  if (age === "adult" && regionCacheAdult) { return; }
+
+  const savedAge = currentAgeContext;
+  const savedCache = evaluationCache;
+
+  currentAgeContext = age;
+  evaluationCache = new Map();
+
+  const cache = buildRegionCache(items);
+
+  if (age === "child") { regionCacheChild = cache; }
+  else { regionCacheAdult = cache; }
+
+  currentAgeContext = savedAge;
+  evaluationCache = savedCache;
+}
+
+/**
+ * Try to collapse a multi-clause expression into a single clause's worth of items.
+ * @param {Expression} expr - The expression to attempt to collapse.
+ * @returns {Array|null} An array of items if collapsible, or null if not.
+ */
+function tryCollapseToCompoundItems(expr) {
+  if (expr.clauses.length < 2) {
+    return null;
+  }
+
+  const singles = [];
+  const multis = [];
+  for (const c of expr.clauses) {
+    if (c.items.length === 1) {
+      singles.push(c.items[0]);
+    } else {
+      multis.push(c.items);
+    }
+  }
+
+  if (singles.length > 0 && multis.length <= 1) {
+    const compound = new CompoundItem(singles);
+    if (multis.length === 1) {
+      compound.nestedOr = multis[0];
+      const orDisplay = multis[0].map(i => i.isCompound ? `(${i.displayName})` : i.displayName).join(" or ");
+      compound.displayName = `${compound.displayName} and (${orDisplay})`;
+      compound.name = `${compound.name}+(${multis[0].map(i => i.name).sort().join("|")})`;
+      compound.owned = singles.every(i => i.owned) && multis[0].some(i => i.owned);
+    }
+    return [compound];
+  }
+
+  // 2 small multi-item clauses, no singles: pair as compound items
+  if (multis.length === 2 && singles.length === 0) {
+    const [m1, m2] = multis;
+
+    // Check for common items first
+    const m1Names = new Set(m1.map(i => i.name));
+    const common = m2.filter(i => m1Names.has(i.name));
+
+    if (common.length > 0) {
+      const commonSet = new Set(common.map(i => i.name));
+      const m1Rest = m1.filter(i => !commonSet.has(i.name));
+      const m2Rest = m2.filter(i => !commonSet.has(i.name));
+      const orItems = [...common];
+      if (m1Rest.length > 0 && m2Rest.length > 0) {
+        let inner;
+        if (m1Rest.length === 1 && m2Rest.length === 1) {
+          inner = new CompoundItem([m1Rest[0], m2Rest[0]]);
+        } else if (m1Rest.length === 1) {
+          inner = new CompoundItem([m1Rest[0]]);
+          inner.nestedOr = m2Rest;
+          const orDisplay = m2Rest.map(i => i.isCompound ? `(${i.displayName})` : i.displayName).join(" or ");
+          inner.displayName = `${m1Rest[0].displayName} and (${orDisplay})`;
+          inner.name = `${m1Rest[0].name}+(${m2Rest.map(i => i.name).sort().join("|")})`;
+          inner.owned = m1Rest[0].owned && m2Rest.some(i => i.owned);
+        } else if (m2Rest.length === 1) {
+          inner = new CompoundItem([m2Rest[0]]);
+          inner.nestedOr = m1Rest;
+          const orDisplay = m1Rest.map(i => i.isCompound ? `(${i.displayName})` : i.displayName).join(" or ");
+          inner.displayName = `${m2Rest[0].displayName} and (${orDisplay})`;
+          inner.name = `${m2Rest[0].name}+(${m1Rest.map(i => i.name).sort().join("|")})`;
+          inner.owned = m2Rest[0].owned && m1Rest.some(i => i.owned);
+        } else {
+          return null;
+        }
+        orItems.push(inner);
+      } else if (m1Rest.length > 0) {
+        orItems.push(...m1Rest);
+      } else if (m2Rest.length > 0) {
+        orItems.push(...m2Rest);
+      }
+      return orItems;
+    }
+
+    // No common items, both small
+    if (m1.length <= 2 && m2.length <= 2) {
+      const [iterItems, nestedItems] = m1.length <= m2.length ? [m1, m2] : [m2, m1];
+      return iterItems.map(item => {
+        const c = new CompoundItem([item]);
+        c.nestedOr = nestedItems;
+        const orDisplay = nestedItems.map(i => i.isCompound ? `(${i.displayName})` : i.displayName).join(" or ");
+        c.displayName = `${item.displayName} and (${orDisplay})`;
+        c.name = `${item.name}+(${nestedItems.map(i => i.name).sort().join("|")})`;
+        c.owned = item.owned && nestedItems.some(i => i.owned);
+        return c;
+      });
+    }
+  }
+
+  return null;
+}
+
+/**
+ * DISTRIBUTIVE LAW: (X+A)·(X+B) = X + (A·B)
+ *
+ * When an item appears in ALL clauses, factor it out into a single OR clause.
+ * The remaining items from each clause are combined into compound AND alternatives.
+ *
+ * This is applied as a final step because it creates CompoundItems which should only exist at the output stage.
+ * @param {Expression} expr - The expression to factor in place.
+ */
+function factorUniversalItems(expr) {
+  if (expr.clauses.length < 2) { return; }
+
+  // Find items present in all clauses
+  const clauseItemNames = expr.clauses.map(clause =>
+    new Set(clause.items.map(i => i.name))
+  );
+  const universalNames = [...clauseItemNames[0]].filter(name =>
+    clauseItemNames.every(names => names.has(name))
+  );
+
+  if (universalNames.length === 0) {
+    // Check if universals exist among only the multi-item clauses
+    const multiItemIndices = [];
+    for (let i = 0; i < expr.clauses.length; i++) {
+      if (expr.clauses[i].items.length > 1) {
+        multiItemIndices.push(i);
+      }
+    }
+
+    if (multiItemIndices.length >= 2) {
+      const multiClauseItemNames = multiItemIndices.map(i =>
+        new Set(expr.clauses[i].items.map(item => item.name))
+      );
+      const multiUniversalNames = [...multiClauseItemNames[0]].filter(name =>
+        multiClauseItemNames.every(names => names.has(name))
+      );
+
+      if (multiUniversalNames.length > 0) {
+        // Separate single-item clauses, factor multi-item clauses, recombine
+        const multiItemSet = new Set(multiItemIndices);
+        const singleClauses = expr.clauses.filter((_, i) => !multiItemSet.has(i));
+        const multiExpr = new Expression(multiItemIndices.map(i => expr.clauses[i]));
+        factorUniversalItems(multiExpr);
+        expr.clauses = [...singleClauses, ...multiExpr.clauses];
+        return;
+      }
+    }
+
+    // Find an item appearing in a subset of clauses, extract it, recursively factor the remainders.
+    // If remainders reduce to a single clause, create a factored clause.
+    const itemToClauseIndices = new Map();
+    for (let i = 0; i < expr.clauses.length; i++) {
+      for (const item of expr.clauses[i].items) {
+        if (!itemToClauseIndices.has(item.name)) {
+          itemToClauseIndices.set(item.name, []);
+        }
+        itemToClauseIndices.get(item.name).push(i);
+      }
+    }
+
+    // Sort candidates by frequency for greedy approach
+    const candidates = [...itemToClauseIndices.entries()]
+      .filter(([, indices]) => indices.length >= 2)
+      .sort((a, b) => b[1].length - a[1].length);
+
+    // Pass 1: try candidates with simple remainders
+    for (const [name, indices] of candidates) {
+      const candidateItem = expr.clauses[indices[0]].items.find(i => i.name === name);
+
+      // Build remainder clauses
+      const remainderClauses = indices.map(i =>
+        new Clause(expr.clauses[i].items.filter(item => item.name !== name))
+      );
+      const nonEmptyRemainders = remainderClauses.filter(c => c.items.length > 0);
+
+      if (nonEmptyRemainders.length < remainderClauses.length) {
+        continue;
+      }
+
+      const remainderExpr = new Expression(nonEmptyRemainders);
+      factorUniversalItems(remainderExpr);
+
+      if (remainderExpr.clauses.length === 1) {
+        // Remainders reduced to 1 clause
+        const factoredClause = new Clause([candidateItem, ...remainderExpr.clauses[0].items]);
+        const groupSet = new Set(indices);
+        expr.clauses = expr.clauses.filter((_, i) => !groupSet.has(i));
+        expr.clauses.push(factoredClause);
+        factorUniversalItems(expr);
+        return;
+      }
+
+      // All single-item remainder clauses
+      if (remainderExpr.clauses.every(c => c.items.length === 1)) {
+        const singleItems = remainderExpr.clauses.map(c => c.items[0]);
+        const compound = new CompoundItem(singleItems);
+        const factoredClause = new Clause([candidateItem, compound]);
+        const groupSet = new Set(indices);
+        expr.clauses = expr.clauses.filter((_, i) => !groupSet.has(i));
+        expr.clauses.push(factoredClause);
+        factorUniversalItems(expr);
+        return;
+      }
+    }
+
+    // Pass 2: try candidates whose remainders can be collapsed into CompoundItems
+    for (const [name, indices] of candidates) {
+      const candidateItem = expr.clauses[indices[0]].items.find(i => i.name === name);
+
+      const remainderClauses = indices.map(i =>
+        new Clause(expr.clauses[i].items.filter(item => item.name !== name))
+      );
+      const nonEmptyRemainders = remainderClauses.filter(c => c.items.length > 0);
+      if (nonEmptyRemainders.length < remainderClauses.length) {
+        continue;
+      }
+
+      const remainderExpr = new Expression(nonEmptyRemainders);
+      factorUniversalItems(remainderExpr);
+
+      const collapsedItems = tryCollapseToCompoundItems(remainderExpr);
+      if (collapsedItems) {
+        const factoredClause = new Clause([candidateItem, ...collapsedItems]);
+        const groupSet = new Set(indices);
+        expr.clauses = expr.clauses.filter((_, i) => !groupSet.has(i));
+        expr.clauses.push(factoredClause);
+        factorUniversalItems(expr);
+        return;
+      }
+    }
+    return;
+  }
+
+  const universalSet = new Set(universalNames);
+  const universalItems = expr.clauses[0].items.filter(i => universalSet.has(i.name));
+
+  // Build remainder items from each clause
+  const remainderPerClause = expr.clauses.map(clause =>
+    clause.items.filter(i => !universalSet.has(i.name))
+  );
+  const nonEmptyRemainders = remainderPerClause.filter(r => r.length > 0);
+
+  if (nonEmptyRemainders.length === 0) {
+    // All clauses were entirely universal items
+    expr.clauses = [new Clause(universalItems)];
+    return;
+  }
+
+  if (nonEmptyRemainders.length < remainderPerClause.length) {
+    // Some clauses became empty after removing universals
+    expr.clauses = [new Clause(universalItems)];
+    return;
+  }
+
+  // All remainder clauses are non-empty. Combine into compound alternatives.
+  // Separate single-item and multi-item remainders for flexible factoring.
+  const singleItems = [];
+  const multiItemClauses = [];
+
+  for (const rem of nonEmptyRemainders) {
+    if (rem.length === 1) {
+      singleItems.push(rem[0]);
+    } else {
+      multiItemClauses.push(rem);
+    }
+  }
+
+  // All single-item remainders
+  if (multiItemClauses.length === 0 && singleItems.length >= 2) {
+    const compound = new CompoundItem(singleItems);
+    expr.clauses = [new Clause([...universalItems, compound])];
+    return;
+  }
+
+  // Single-items + 1 multi-item
+  if (multiItemClauses.length === 1 && singleItems.length >= 1) {
+    const compound = new CompoundItem(singleItems);
+    compound.nestedOr = multiItemClauses[0];
+    const nestedOrDisplay = multiItemClauses[0].map(i => i.displayName).join(" or ");
+    compound.displayName = `${compound.displayName} and (${nestedOrDisplay})`;
+    compound.name = `${compound.name}+(${multiItemClauses[0].map(i => i.name).sort().join("|")})`;
+    expr.clauses = [new Clause([...universalItems, compound])];
+    return;
+  }
+
+  // 2 multi-item clauses
+  if (multiItemClauses.length === 2) {
+    const [mc1, mc2] = multiItemClauses;
+    const mc1Names = new Set(mc1.map(i => i.name));
+    const commonItems = mc2.filter(i => mc1Names.has(i.name));
+
+    if (commonItems.length > 0) {
+      const commonSet = new Set(commonItems.map(i => i.name));
+      const mc1Rem = mc1.filter(i => !commonSet.has(i.name));
+      const mc2Rem = mc2.filter(i => !commonSet.has(i.name));
+
+      const nestedOrItems = [...commonItems];
+      if (mc1Rem.length > 0 && mc2Rem.length > 0) {
+        let innerCompound;
+        if (mc1Rem.length === 1 && mc2Rem.length === 1) {
+          // Both single: simple AND compound
+          innerCompound = new CompoundItem([mc1Rem[0], mc2Rem[0]]);
+        } else if (mc1Rem.length === 1) {
+          // Single AND (multi OR)
+          innerCompound = new CompoundItem([mc1Rem[0]]);
+          innerCompound.nestedOr = mc2Rem;
+          const orDisplay = mc2Rem.map(i => i.displayName).join(" or ");
+          innerCompound.displayName = `${mc1Rem[0].displayName} and (${orDisplay})`;
+          innerCompound.name = `${mc1Rem[0].name}+(${mc2Rem.map(i => i.name).sort().join("|")})`;
+          innerCompound.owned = mc1Rem[0].owned && mc2Rem.some(i => i.owned);
+        } else if (mc2Rem.length === 1) {
+          // (multi OR) AND single
+          innerCompound = new CompoundItem([mc2Rem[0]]);
+          innerCompound.nestedOr = mc1Rem;
+          const orDisplay = mc1Rem.map(i => i.displayName).join(" or ");
+          innerCompound.displayName = `${mc2Rem[0].displayName} and (${orDisplay})`;
+          innerCompound.name = `${mc2Rem[0].name}+(${mc1Rem.map(i => i.name).sort().join("|")})`;
+          innerCompound.owned = mc2Rem[0].owned && mc1Rem.some(i => i.owned);
+        } else {
+          // Both multi
+          innerCompound = new CompoundItem([...mc1Rem, ...mc2Rem]);
+        }
+        nestedOrItems.push(innerCompound);
+      } else if (mc1Rem.length > 0) {
+        nestedOrItems.push(...mc1Rem);
+      } else if (mc2Rem.length > 0) {
+        nestedOrItems.push(...mc2Rem);
+      }
+
+      if (singleItems.length > 0) {
+        const compound = new CompoundItem(singleItems);
+        compound.nestedOr = nestedOrItems;
+        const nestedOrDisplay = nestedOrItems.map(i =>
+          i.isCompound ? `(${i.displayName})` : i.displayName
+        ).join(" or ");
+        compound.displayName = `${compound.displayName} and (${nestedOrDisplay})`;
+        compound.name = `${compound.name}+(${nestedOrItems.map(i => i.name).sort().join("|")})`;
+        expr.clauses = [new Clause([...universalItems, compound])];
+      } else {
+        expr.clauses = [new Clause([...universalItems, ...nestedOrItems])];
+      }
+      return;
+    }
+
+    if (singleItems.length === 0 && mc1.length <= 2 && mc2.length <= 2) {
+      // Both remainders small with no common items.
+      // Factor each item from one clause with the other as nestedOr.
+      const [iterItems, nestedItems] = mc1.length <= mc2.length ? [mc1, mc2] : [mc2, mc1];
+      const compounds = iterItems.map(item => {
+        const compound = new CompoundItem([item]);
+        compound.nestedOr = nestedItems;
+        const nestedOrDisplay = nestedItems.map(i =>
+          i.isCompound ? `(${i.displayName})` : i.displayName
+        ).join(" or ");
+        compound.displayName = `${item.displayName} and (${nestedOrDisplay})`;
+        compound.name = `${item.name}+(${nestedItems.map(i => i.name).sort().join("|")})`;
+        compound.owned = item.owned && nestedItems.some(i => i.owned);
+        return compound;
+      });
+      expr.clauses = [new Clause([...universalItems, ...compounds])];
+      return;
+    }
+  }
+
+  // Create sub-expression from all remainder clauses and factor recursively
+  const subClauses = [];
+  for (const items of multiItemClauses) {
+    subClauses.push(new Clause(items));
+  }
+  for (const item of singleItems) {
+    subClauses.push(new Clause([item]));
+  }
+  if (subClauses.length < 2) {
+    if (subClauses.length === 1) {
+      expr.clauses = [new Clause([...universalItems, ...subClauses[0].items])];
+    }
+    return;
+  }
+
+  const subExpr = new Expression(subClauses);
+  factorUniversalItems(subExpr);
+
+  if (subExpr.clauses.length === 1) {
+    expr.clauses = [new Clause([...universalItems, ...subExpr.clauses[0].items])];
+    return;
+  }
+
+  // Try converting multi-clause sub-expression into a single CompoundItem
+  const subSingles = [];
+  const subMulti = [];
+  for (const clause of subExpr.clauses) {
+    if (clause.items.length === 1) {
+      subSingles.push(clause.items[0]);
+    } else {
+      subMulti.push(clause.items);
+    }
+  }
+
+  if (subMulti.length <= 1 && subSingles.length > 0) {
+    // Can represent as CompoundItem with optional nestedOr
+    const compound = new CompoundItem(subSingles);
+    if (subMulti.length === 1) {
+      compound.nestedOr = subMulti[0];
+      const nestedOrDisplay = subMulti[0].map(i =>
+        i.isCompound ? `(${i.displayName})` : i.displayName
+      ).join(" or ");
+      compound.displayName = `${compound.displayName} and (${nestedOrDisplay})`;
+      compound.name = `${compound.name}+(${subMulti[0].map(i => i.name).sort().join("|")})`;
+    }
+    expr.clauses = [new Clause([...universalItems, compound])];
+    return;
+  }
+
+  // If can't fully collapse, reconstruct with universals in each clause
+  expr.clauses = subExpr.clauses.map(c => new Clause([...universalItems, ...c.items]));
+}
+
+/**
+ * Produce a canonical string signature for an Expression.
+ * @param {Expression} expr - The expression to produce a signature for.
+ * @returns {string} The canonical signature string.
+ */
+function expressionSignature(expr) {
+  return expr.clauses
+    .map(c => c.items.map(i => i.name).sort().join("|"))
+    .sort()
+    .join("&");
+}
+
+/**
+ * Evaluate region access and location rule requirements for a specific age context.
+ * @param {object} rule - The parsed AST rule node for the location.
+ * @param {string} parentRegion - The region to evaluate access for.
+ * @param {object} items - Current tracked items.
+ * @returns {Expression|null} The requirements, or null if impossible.
+ */
+function evaluateForAge(rule, parentRegion, items) {
+  const regionCache = getActiveRegionCache();
+  let regionExpr;
+
+  if (regionCache?.has(parentRegion)) {
+    regionExpr = regionCache.get(parentRegion).clone();
+  } else if (ENTRY_POINT_REGIONS.has(parentRegion)) {
+    // Entry points are always accessible
+    regionExpr = new Expression();
+  } else {
+    // Region not reachable
+    return null;
+  }
+
+  // Bean planting special case: child must reach the region to plant
+  if (containsBeanPlanting(rule)) {
+    const childExpr = regionCacheChild?.get(parentRegion)?.clone();
+    if (childExpr && !childExpr.isEmpty() && !childExpr.isImpossible()) {
+      if (currentAgeContext !== null) {
+        // Age-specific context: store child region for here(can_plant_bean) to merge into just the bean sub-expression,
+        // not the entire region expression. This lets non-bean branches use the age-specific cache.
+        beanPlantingChildRegionExpr = childExpr;
+      } else {
+        // Age-neutral context: replace region with child cache
+        regionExpr = childExpr;
+      }
+    }
+  }
+
+  const locationExpr = extractFromNode(rule, items, new Set(), 0);
+
+  // Clear after extraction
+  beanPlantingChildRegionExpr = null;
+
+  regionExpr.merge(locationExpr);
+  regionExpr.simplify();
+
+  if (regionExpr.isImpossible()) {
+    return null;
+  }
+
+  return regionExpr;
+}
+
+/**
+ * Post-process an Expression into the output clause format.
+ * @param {Expression} regionExpr - The expression to post-process.
+ * @returns {{ clauses: Array, satisfied: boolean }} The formatted requirements structure.
+ */
+function postProcessExpression(regionExpr) {
+  // Factor universal items from PoS expressions into compound alternatives
+  factorUniversalItems(regionExpr);
+
+  // Factor common items from compound options within OR clauses
+  for (const clause of regionExpr.clauses) {
+    if (clause.items.length > 1) {
+      clause.items = factorCompoundsWithSharedItems(clause.items);
+      clause.items = simplifyOrBySubset(clause.items);
+    }
+  }
+
+  // Convert internal item to output format
+  const convertItem = (item) => {
+    if (item.isCompound) {
+      const result = {
+        name: item.name,
+        displayName: item.displayName,
+        owned: item.owned,
+        isEvent: false,
+        isCompound: true,
+        subItems: item.items.map(convertItem),
+      };
+
+      if (item.nestedOr && item.nestedOr.length > 0) {
+        result.nestedOr = item.nestedOr.map(convertItem);
+      }
+
+      return result;
+    }
+
+    return {
+      name: item.name,
+      displayName: item.displayName,
+      owned: item.owned,
+      isEvent: item.isEvent,
+    };
+  };
+
+  // Convert to output format
+  const clauses = regionExpr.clauses.map(clause => ({
+    items: clause.items.map(convertItem),
+  }));
+
+  // Simplify redundant top-level age requirements
+  const simplifiedClauses = simplifyTopLevelAge(clauses);
+
+  // Sort clauses: simpler clauses first, then alphabetically
+  simplifiedClauses.sort((a, b) => {
+    const aHasCompound = a.items.some(item => item.isCompound);
+    const bHasCompound = b.items.some(item => item.isCompound);
+    if (aHasCompound !== bHasCompound) {
+      return aHasCompound ? 1 : -1;
+    }
+    if (a.items.length !== b.items.length) {
+      return a.items.length - b.items.length;
+    }
+
+    const aName = a.items[0]?.displayName || "";
+    const bName = b.items[0]?.displayName || "";
+    return aName.localeCompare(bName);
+  });
+
+  const satisfied = regionExpr.isEmpty() || regionExpr.isSatisfied();
+  return { clauses: simplifiedClauses, satisfied };
+}
+
+/**
+ * Compute and return the item requirements to access a specific location.
+ *
+ * Evaluates region accessibility and location rule for each applicable age context, combines results,
+ * and post-processes into the output clause format.
+ * @param {string} locationName - The location name as used in logic files.
+ * @param {object} items - The current tracked items object.
+ * @returns {{ clauses: Array, satisfied: boolean }} The requirements structure.
+ */
+export function getLocationRequirements(locationName, items) {
+  const location = Locations.getLocation(locationName);
+  if (!location) {
+    return { clauses: [], satisfied: true };
+  }
+
+  const { rule: locationRule, parentRegion: locationRegion } = location;
+
+  // Boss defeat locations:
+  // The location rule is a Defeat event reference. Boss fight items are trivially satisfied via shop consumables.
+  // Replace the Defeat rule with true and let the region cache handle navigation from the boss room to root.
+  let rule = locationRule;
+  const parentRegion = locationRegion;
+  const ruleExpr = locationRule.type === "ExpressionStatement" ? locationRule.expression : locationRule;
+  if (ruleExpr.type === "Literal" && typeof ruleExpr.value === "string" && ruleExpr.value.startsWith("Defeat ")) {
+    rule = { type: "Literal", value: true };
+  }
+
+  const ageRequirement = detectAgeRequirement(rule);
+
+  cachedSettings = LogicHelper.settings;
+
+  try {
+    // Always build both age caches.
+    // Age-specific locations still need both caches for dual-age evaluation.
+    ensureRegionCache("child", items);
+    ensureRegionCache("adult", items);
+
+    // When no age is detected from the location rule, evaluate for each age separately to maintain age consistency
+    // across paths. A player can only be one age at a time. The cache ensures consistent age assumptions.
+    // This applies regardless of starting_age since the player can always time travel.
+    if (!ageRequirement) {
+      const ageExprs = [];
+
+      for (const age of ["child", "adult"]) {
+        currentAgeContext = age;
+        evaluationCache = new Map();
+
+        const result = evaluateForAge(rule, parentRegion, items);
+        if (result) {
+          ageExprs.push(result);
+        }
+      }
+
+      currentAgeContext = null;
+      evaluationCache = new Map();
+
+      if (ageExprs.length === 0) {
+        return { clauses: [], satisfied: true };
+      }
+
+      // Short-circuit: only one age produced a valid result
+      if (ageExprs.length === 1) {
+        return postProcessExpression(ageExprs[0]);
+      }
+
+      // Short-circuit: both ages produce equivalent results
+      const sig0 = expressionSignature(ageExprs[0]);
+      const sig1 = expressionSignature(ageExprs[1]);
+      if (sig0 === sig1) {
+        return postProcessExpression(ageExprs[0]);
+      }
+
+      // Different results for child vs adult: combine with proper Product-of-Sums OR
+      const combined = orCombineExpressions(ageExprs[0], ageExprs[1]);
+      return postProcessExpression(combined);
+    }
+
+    // Fixed starting age or age-specific rule: single evaluation
+    currentAgeContext = ageRequirement;
+    evaluationCache = new Map();
+
+    const result = evaluateForAge(rule, parentRegion, items);
+    if (!result) {
+      return { clauses: [], satisfied: true };
+    }
+
+    return postProcessExpression(result);
+  } finally {
+    currentAgeContext = null;
+    cachedSettings = null;
+    evaluationCache = null;
+  }
+}
+
+/**
+ * Return the cached requirements structure for a location, recomputing when settings change.
+ *
+ * Uses starting items to produce a static structure that is then updated with ownership.
+ * @param {string} locationName - The location name as used in logic files.
+ * @returns {{ clauses: Array, satisfied: boolean }} The cached requirements structure.
+ */
+export function getRequirementsStructure(locationName) {
+  // Check if settings have changed and invalidate cache if so
+  const currentSettings = LogicHelper.settings;
+  const currentSettingsJson = JSON.stringify(currentSettings);
+
+  if (currentSettingsJson !== lastSettingsJson) {
+    structureCache.clear();
+    lastSettingsJson = currentSettingsJson;
+    regionCacheChild = null;
+    regionCacheAdult = null;
+  }
+
+  // Check cache first
+  if (structureCache.has(locationName)) {
+    return structureCache.get(locationName);
+  }
+
+  // Compute and cache the result
+  const startingItems = LogicHelper.getStartingItems();
+  const result = getLocationRequirements(locationName, startingItems);
+
+  structureCache.set(locationName, result);
+  return result;
+}
+
+/**
+ * Update the owned flags in a requirements structure based on current items.
+ *
+ * Recursively updates simple and compound items, preserving the clause structure.
+ * Returns the original object unchanged if already satisfied or empty.
+ * @param {{ clauses: Array, satisfied: boolean }} requirements - The requirements structure to update.
+ * @param {object} currentItems - The current tracked items object.
+ * @returns {{ clauses: Array, satisfied: boolean }} A new requirements object with updated ownership.
+ */
+export function updateRequirementsOwnership(requirements, currentItems) {
+  if (!requirements || requirements.satisfied || requirements.clauses.length === 0) {
+    return requirements;
+  }
+
+  // Helper to recursively update ownership for any item
+  const updateNestedItem = (item) => {
+    if (item.isCompound && item.subItems) {
+      const updatedSubItems = item.subItems.map(updateNestedItem);
+      const subItemsOwned = updatedSubItems.every(si => si.owned);
+
+      let updatedNestedOr = null;
+      let nestedOrSatisfied = false;
+      if (item.nestedOr && item.nestedOr.length > 0) {
+        updatedNestedOr = item.nestedOr.map(updateNestedItem);
+        nestedOrSatisfied = updatedNestedOr.some(ni => ni.owned);
+      }
+
+      return {
+        ...item,
+        subItems: updatedSubItems,
+        nestedOr: updatedNestedOr,
+        owned: subItemsOwned && (!updatedNestedOr || nestedOrSatisfied),
+      };
+    }
+    return {
+      ...item,
+      owned: isItemOwned(item.name, currentItems),
+    };
+  };
+
+  // Deep clone and update ownership recursively
+  const updated = {
+    clauses: requirements.clauses.map(clause => ({
+      items: clause.items.map(updateNestedItem),
+    })),
+    satisfied: requirements.satisfied,
+  };
+
+  return updated;
+}
+
+/**
+ * Clear the structure cache. Call this when logic files are reloaded.
+ */
+export function clearStructureCache() {
+  structureCache.clear();
+  lastSettingsJson = null;
+  regionCacheChild = null;
+  regionCacheAdult = null;
+}
+
+export default { getLocationRequirements, getRequirementsStructure, updateRequirementsOwnership, clearStructureCache };

--- a/src/utils/expression-converter.test.js
+++ b/src/utils/expression-converter.test.js
@@ -1,0 +1,445 @@
+import BUNDLE from "../versions/bundles/9.0.0";
+import {
+  clearStructureCache,
+  getLocationRequirements,
+  getRequirementsStructure,
+  updateRequirementsOwnership,
+} from "./expression-converter";
+import Locations from "./locations";
+import LogicHelper from "./logic-helper";
+import SettingsHelper from "./settings-helper";
+
+
+/**
+ * Initialize all logic systems with optional settings overrides.
+ * @param {object} settingsOverrides - Settings to override bundle defaults.
+ */
+function initializeLogic(settingsOverrides = {}) {
+  const { logicHelpersFile, dungeonFiles, dungeonMQFiles, bossesFile, overworldFile } = BUNDLE;
+  SettingsHelper.initialize(BUNDLE);
+  Locations.initialize(dungeonFiles, dungeonMQFiles, bossesFile, overworldFile);
+  SettingsHelper.setSettings(settingsOverrides);
+  LogicHelper.initialize(logicHelpersFile, SettingsHelper.settings);
+  clearStructureCache();
+}
+
+/** Restore default settings. */
+function restoreDefaultSettings() {
+  initializeLogic();
+}
+
+/**
+ * Format an item for display, handling compound items.
+ * @param {object} item - The requirement item to format.
+ * @param {boolean} needsParens - Whether to wrap compound items in parentheses.
+ * @returns {string} The formatted display string.
+ */
+function formatItemForOr(item, needsParens) {
+  if (item.isCompound) {
+    if (item.nestedOr && item.nestedOr.length > 0) {
+      const baseDisplay = item.subItems.map((si) => si.displayName).join(" and ");
+      const nestedOrDisplay = item.nestedOr
+        .map((nestedItem) => {
+          if (nestedItem.isCompound) {
+            return `(${nestedItem.displayName})`;
+          }
+          return nestedItem.displayName;
+        })
+        .join(" or ");
+      const fullDisplay = `${baseDisplay} and (${nestedOrDisplay})`;
+      return needsParens ? `(${fullDisplay})` : fullDisplay;
+    }
+    return needsParens ? `(${item.displayName})` : item.displayName;
+  }
+  return item.displayName;
+}
+
+/**
+ * Convert Expression requirements to a human-readable string.
+ * @param {object} result - The requirements object with clauses and satisfied flag.
+ * @returns {string} Human-readable requirements string.
+ */
+function requirementsToSimpleString(result) {
+  if (!result || result.satisfied || result.clauses.length === 0) {
+    return "Nothing";
+  }
+
+  if (result.clauses.length === 1) {
+    const clause = result.clauses[0];
+    const hasMultipleItems = clause.items.length > 1;
+    const itemNames = clause.items.map((item) => formatItemForOr(item, hasMultipleItems));
+    return itemNames.join(" or ");
+  }
+
+  const clauseStrings = result.clauses.map((clause) => {
+    const hasMultipleItems = clause.items.length > 1;
+    const itemNames = clause.items.map((item) => formatItemForOr(item, hasMultipleItems));
+
+    if (itemNames.length === 1) {
+      return itemNames[0];
+    }
+    return `(${itemNames.join(" or ")})`;
+  });
+
+  return clauseStrings.join(" AND ");
+}
+
+
+describe("updateRequirementsOwnership", () => {
+  beforeAll(() => initializeLogic());
+  afterAll(restoreDefaultSettings);
+
+  test("returns input unchanged when satisfied is true", () => {
+    const req = { clauses: [], satisfied: true };
+    expect(updateRequirementsOwnership(req, {})).toBe(req);
+  });
+
+  test("returns input unchanged when clauses is empty", () => {
+    const req = { clauses: [], satisfied: false };
+    expect(updateRequirementsOwnership(req, {})).toBe(req);
+  });
+
+  test("returns input unchanged when null", () => {
+    expect(updateRequirementsOwnership(null, {})).toBe(null);
+  });
+
+  test("updates simple item owned flag based on items dict", () => {
+    const req = {
+      clauses: [{ items: [{ name: "Bow", displayName: "Bow", owned: false, isEvent: false }] }],
+      satisfied: false,
+    };
+    const result = updateRequirementsOwnership(req, { Bow: 1 });
+    expect(result.clauses[0].items[0].owned).toBe(true);
+  });
+
+  test("simple item without count stays unowned", () => {
+    const req = {
+      clauses: [{ items: [{ name: "Bow", displayName: "Bow", owned: false, isEvent: false }] }],
+      satisfied: false,
+    };
+    const result = updateRequirementsOwnership(req, {});
+    expect(result.clauses[0].items[0].owned).toBe(false);
+  });
+
+  test("compound item: all subItems owned makes compound owned", () => {
+    const req = {
+      clauses: [
+        {
+          items: [
+            {
+              name: "A+B",
+              displayName: "A and B",
+              owned: false,
+              isCompound: true,
+              subItems: [
+                { name: "Bow", displayName: "Bow", owned: false, isEvent: false },
+                { name: "Bomb_Bag", displayName: "Bombs", owned: false, isEvent: false },
+              ],
+              nestedOr: null,
+            },
+          ],
+        },
+      ],
+      satisfied: false,
+    };
+    const result = updateRequirementsOwnership(req, { Bow: 1, Bomb_Bag: 1 });
+    expect(result.clauses[0].items[0].owned).toBe(true);
+    expect(result.clauses[0].items[0].subItems[0].owned).toBe(true);
+    expect(result.clauses[0].items[0].subItems[1].owned).toBe(true);
+  });
+
+  test("compound item: one subItem unowned makes compound not owned", () => {
+    const req = {
+      clauses: [
+        {
+          items: [
+            {
+              name: "A+B",
+              displayName: "A and B",
+              owned: false,
+              isCompound: true,
+              subItems: [
+                { name: "Bow", displayName: "Bow", owned: false, isEvent: false },
+                { name: "Bomb_Bag", displayName: "Bombs", owned: false, isEvent: false },
+              ],
+              nestedOr: null,
+            },
+          ],
+        },
+      ],
+      satisfied: false,
+    };
+    const result = updateRequirementsOwnership(req, { Bow: 1 });
+    expect(result.clauses[0].items[0].owned).toBe(false);
+  });
+
+  test("nestedOr: subItems owned + some nestedOr owned = compound owned", () => {
+    const req = {
+      clauses: [
+        {
+          items: [
+            {
+              name: "compound",
+              displayName: "compound",
+              owned: false,
+              isCompound: true,
+              subItems: [{ name: "Bow", displayName: "Bow", owned: false, isEvent: false }],
+              nestedOr: [
+                { name: "Bomb_Bag", displayName: "Bombs", owned: false, isEvent: false },
+                { name: "Slingshot", displayName: "Slingshot", owned: false, isEvent: false },
+              ],
+            },
+          ],
+        },
+      ],
+      satisfied: false,
+    };
+    const result = updateRequirementsOwnership(req, { Bow: 1, Bomb_Bag: 1 });
+    expect(result.clauses[0].items[0].owned).toBe(true);
+  });
+
+  test("nestedOr: subItems owned but no nestedOr owned = compound not owned", () => {
+    const req = {
+      clauses: [
+        {
+          items: [
+            {
+              name: "compound",
+              displayName: "compound",
+              owned: false,
+              isCompound: true,
+              subItems: [{ name: "Bow", displayName: "Bow", owned: false, isEvent: false }],
+              nestedOr: [
+                { name: "Bomb_Bag", displayName: "Bombs", owned: false, isEvent: false },
+                { name: "Slingshot", displayName: "Slingshot", owned: false, isEvent: false },
+              ],
+            },
+          ],
+        },
+      ],
+      satisfied: false,
+    };
+    const result = updateRequirementsOwnership(req, { Bow: 1 });
+    expect(result.clauses[0].items[0].owned).toBe(false);
+  });
+
+  test("does not mutate input", () => {
+    const original = {
+      clauses: [{ items: [{ name: "Bow", displayName: "Bow", owned: false, isEvent: false }] }],
+      satisfied: false,
+    };
+    updateRequirementsOwnership(original, { Bow: 1 });
+    expect(original.clauses[0].items[0].owned).toBe(false);
+  });
+
+  test("handles counted items", () => {
+    const req = {
+      clauses: [
+        {
+          items: [
+            {
+              name: "Progressive_Hookshot,2",
+              displayName: "Hookshot x2",
+              owned: false,
+              isEvent: false,
+            },
+          ],
+        },
+      ],
+      satisfied: false,
+    };
+    const result = updateRequirementsOwnership(req, { Progressive_Hookshot: 2 });
+    expect(result.clauses[0].items[0].owned).toBe(true);
+
+    const result2 = updateRequirementsOwnership(req, { Progressive_Hookshot: 1 });
+    expect(result2.clauses[0].items[0].owned).toBe(false);
+  });
+});
+
+
+describe("getLocationRequirements", () => {
+  describe("with default settings (starting_age: child)", () => {
+    beforeAll(() => initializeLogic({ starting_age: "child" }));
+    afterAll(restoreDefaultSettings);
+
+    test("returns { clauses, satisfied } structure", () => {
+      const result = getLocationRequirements("KF Midos Top Left Chest", {});
+      expect(result).toHaveProperty("clauses");
+      expect(result).toHaveProperty("satisfied");
+      expect(Array.isArray(result.clauses)).toBe(true);
+    });
+
+    test("returns satisfied for unknown location", () => {
+      const result = getLocationRequirements("Nonexistent Location XYZ", {});
+      expect(result.satisfied).toBe(true);
+    });
+
+    test("returns non-empty requirements for a gated location", () => {
+      const result = getLocationRequirements("ZD King Zora Thawed", {});
+      const str = requirementsToSimpleString(result);
+      expect(str).not.toBe("Nothing");
+    });
+
+    test("result items have name, displayName, and owned fields", () => {
+      const result = getLocationRequirements("ZD King Zora Thawed", {});
+      expect(result.clauses.length).toBeGreaterThan(0);
+      const firstItem = result.clauses[0].items[0];
+      expect(firstItem).toHaveProperty("name");
+      expect(firstItem).toHaveProperty("displayName");
+      expect(firstItem).toHaveProperty("owned");
+    });
+
+    test("with fixed starting_age: child, results have no age identifiers", () => {
+      const result = getLocationRequirements("ZD King Zora Thawed", {});
+      const str = requirementsToSimpleString(result);
+      expect(str).not.toContain("is adult");
+      expect(str).not.toContain("is child");
+    });
+
+    test("KF Kokiri Sword Chest requires nothing", () => {
+      const result = getLocationRequirements("KF Kokiri Sword Chest", {});
+      const str = requirementsToSimpleString(result);
+      expect(str).toBe("Nothing");
+    });
+
+    test("bean patch location shows bottle requirement", () => {
+      const result = getLocationRequirements("KF GS Bean Patch", {});
+      const str = requirementsToSimpleString(result);
+      expect(str.toLowerCase()).toMatch(/bottle/);
+    });
+  });
+});
+
+
+describe("bridge condition: medallions", () => {
+  beforeAll(() => initializeLogic({ bridge: "medallions", bridge_medallions: 6 }));
+  afterAll(restoreDefaultSettings);
+
+  test("Ganons Castle shows all 6 medallion requirements", () => {
+    const result = getLocationRequirements("Ganons Castle Forest Trial Chest", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).toContain("Fire Medallion");
+    expect(str).toContain("Forest Medallion");
+    expect(str).toContain("Light Medallion");
+    expect(str).toContain("Shadow Medallion");
+    expect(str).toContain("Spirit Medallion");
+    expect(str).toContain("Water Medallion");
+  });
+});
+
+describe("Thieves Hideout keysanity", () => {
+  beforeAll(() => initializeLogic({ shuffle_hideoutkeys: "keysanity" }));
+  afterAll(restoreDefaultSettings);
+
+  test("Gerudo Membership Card shows key requirement", () => {
+    const result = getLocationRequirements("Hideout Gerudo Membership Card", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).toMatch(/Thieves Hideout Small Key/);
+  });
+
+  test("Key location should not require keys", () => {
+    const result = getLocationRequirements("Hideout 1 Torch Jail Gerudo Key", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).not.toMatch(/Small Key/);
+  });
+});
+
+describe("Adult trade shuffle", () => {
+  beforeAll(() => initializeLogic({ adult_trade_shuffle: true, adult_trade_start: ["Pocket Egg"] }));
+  afterAll(restoreDefaultSettings);
+
+  test("LW Trade Cojiro requires Cojiro, not the full vanilla chain", () => {
+    const result = getLocationRequirements("LW Trade Cojiro", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).toMatch(/Cojiro/);
+    expect(str).not.toMatch(/Pocket Egg/);
+    expect(str).not.toMatch(/Pocket Cucco/);
+  });
+});
+
+describe("Ocarina notes shuffle", () => {
+  beforeAll(() => initializeLogic({ shuffle_individual_ocarina_notes: true }));
+  afterAll(restoreDefaultSettings);
+
+  test("LW Ocarina Memory Game shows note requirements", () => {
+    const result = getLocationRequirements("LW Ocarina Memory Game", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).toMatch(/Ocarina A Button/);
+    expect(str).toMatch(/Ocarina C/);
+  });
+
+  test("without note shuffle, notes should not appear", () => {
+    initializeLogic({ shuffle_individual_ocarina_notes: false });
+    const result = getLocationRequirements("LW Ocarina Memory Game", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).not.toMatch(/Ocarina.*Button/);
+    initializeLogic({ shuffle_individual_ocarina_notes: true });
+  });
+});
+
+describe("Ganon's Tower trials", () => {
+  afterAll(restoreDefaultSettings);
+
+  test("0 trials: should not require trials", () => {
+    initializeLogic({ trials: 0 });
+    const result = getLocationRequirements("Ganons Tower Boss Key Chest", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).not.toMatch(/Trials/);
+  });
+
+  test("6 trials: should show Light Arrows", () => {
+    initializeLogic({ trials: 6 });
+    const result = getLocationRequirements("Ganons Tower Boss Key Chest", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).toMatch(/Light Arrows/);
+    expect(str).not.toMatch(/Trials Cleared/);
+  });
+
+  test("4 trials: should show Trials Cleared x4", () => {
+    initializeLogic({ trials: 4 });
+    const result = getLocationRequirements("Ganons Tower Boss Key Chest", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).toMatch(/Trials Cleared x4/);
+  });
+
+  test("random trials: should show Trials Cleared", () => {
+    initializeLogic({ trials: 3, trials_random: true });
+    const result = getLocationRequirements("Ganons Tower Boss Key Chest", {});
+    const str = requirementsToSimpleString(result);
+    expect(str).toMatch(/Trials Cleared/);
+  });
+});
+
+
+describe("getRequirementsStructure", () => {
+  beforeAll(() => initializeLogic());
+  afterAll(restoreDefaultSettings);
+
+  test("returns same structure as getLocationRequirements", () => {
+    const result = getRequirementsStructure("KF Kokiri Sword Chest");
+    expect(result).toHaveProperty("clauses");
+    expect(result).toHaveProperty("satisfied");
+  });
+
+  test("caches results (second call returns same reference)", () => {
+    const r1 = getRequirementsStructure("KF Kokiri Sword Chest");
+    const r2 = getRequirementsStructure("KF Kokiri Sword Chest");
+    expect(r1).toBe(r2);
+  });
+
+  test("clearStructureCache invalidates the cache", () => {
+    const r1 = getRequirementsStructure("KF Kokiri Sword Chest");
+    clearStructureCache();
+    const r2 = getRequirementsStructure("KF Kokiri Sword Chest");
+    expect(r1).not.toBe(r2);
+  });
+});
+
+describe("clearStructureCache", () => {
+  beforeAll(() => initializeLogic());
+  afterAll(restoreDefaultSettings);
+
+  test("calling does not throw", () => {
+    expect(() => clearStructureCache()).not.toThrow();
+  });
+});

--- a/src/utils/expression-data.js
+++ b/src/utils/expression-data.js
@@ -1,0 +1,669 @@
+import memoize from "memoizee";
+
+// Maps logic item names to human-readable display names shown in tooltips.
+const DISPLAY_NAMES = {
+  Progressive_Hookshot: "Hookshot",
+  Progressive_Strength_Upgrade: "Strength",
+  Progressive_Scale: "Scale",
+  Progressive_Wallet: "Wallet",
+  Bomb_Bag: "Bombs",
+  Bow: "Bow",
+  Slingshot: "Slingshot",
+  Boomerang: "Boomerang",
+  Ocarina: "Ocarina",
+  Bombchus: "Bombchus",
+  Magic_Meter: "Magic",
+  Dins_Fire: "Din's Fire",
+  Farores_Wind: "Farore's Wind",
+  Nayrus_Love: "Nayru's Love",
+  Fire_Arrows: "Fire Arrows",
+  Ice_Arrows: "Ice Arrows",
+  Light_Arrows: "Light Arrows",
+  Lens_of_Truth: "Lens of Truth",
+  Megaton_Hammer: "Hammer",
+  Iron_Boots: "Iron Boots",
+  Hover_Boots: "Hover Boots",
+  Mirror_Shield: "Mirror Shield",
+  Goron_Tunic: "Goron Tunic",
+  Zora_Tunic: "Zora Tunic",
+  Kokiri_Sword: "Kokiri Sword",
+  Master_Sword: "Master Sword",
+  Biggoron_Sword: "Biggoron Sword",
+  Deku_Shield: "Deku Shield",
+  Hylian_Shield: "Hylian Shield",
+  Bottle: "Bottle",
+  Rutos_Letter: "Ruto's Letter",
+  Zeldas_Letter: "Zelda's Letter",
+  Stone_of_Agony: "Stone of Agony",
+  Gerudo_Membership_Card: "Gerudo Card",
+  Gold_Skulltula_Token: "Skulltula Token",
+  Piece_of_Heart: "Heart Piece",
+  Heart_Container: "Heart Container",
+  Magic_Bean: "Magic Bean",
+  Deku_Stick_Capacity: "Deku Stick Upgrade",
+  Deku_Nut_Capacity: "Deku Nut Upgrade",
+
+  Zeldas_Lullaby: "Zelda's Lullaby",
+  Eponas_Song: "Epona's Song",
+  Sarias_Song: "Saria's Song",
+  Suns_Song: "Sun's Song",
+  Song_of_Time: "Song of Time",
+  Song_of_Storms: "Song of Storms",
+  Minuet_of_Forest: "Minuet of Forest",
+  Bolero_of_Fire: "Bolero of Fire",
+  Serenade_of_Water: "Serenade of Water",
+  Requiem_of_Spirit: "Requiem of Spirit",
+  Nocturne_of_Shadow: "Nocturne of Shadow",
+  Prelude_of_Light: "Prelude of Light",
+
+  Kokiri_Emerald: "Kokiri Emerald",
+  Goron_Ruby: "Goron Ruby",
+  Zora_Sapphire: "Zora Sapphire",
+  Forest_Medallion: "Forest Medallion",
+  Fire_Medallion: "Fire Medallion",
+  Water_Medallion: "Water Medallion",
+  Shadow_Medallion: "Shadow Medallion",
+  Spirit_Medallion: "Spirit Medallion",
+  Light_Medallion: "Light Medallion",
+};
+
+
+class RequirementItem {
+  /**
+   * Constructs a leaf requirement node representing a single collectible item or event.
+   * @param {string} name - The canonical logic item name.
+   * @param {string} displayName - The human-readable display name shown in tooltips.
+   * @param {boolean} owned - Whether the player currently owns this item.
+   * @param {boolean} isEvent - Whether this item represents an event rather than a collectible.
+   */
+  constructor(name, displayName, owned, isEvent = false) {
+    this.isCompound = false;
+
+    this.name = name;
+    this.displayName = displayName;
+    this.owned = owned;
+    this.isEvent = isEvent;
+  }
+}
+
+class CompoundItem {
+  /**
+   * Constructs a CompoundItem representing an AND of items.
+   *
+   * Flattens nested CompoundItems and deduplicates by name.
+   * @param {Array} items - Array of RequirementItem or CompoundItem instances.
+   */
+  constructor(items = []) {
+    // Flatten nested CompoundItems without nestedOr then deduplicate by name
+    const flat = [];
+    for (const item of items) {
+      if (item.isCompound && !item.nestedOr) {
+        flat.push(...item.items);
+      } else {
+        flat.push(item);
+      }
+    }
+
+    const seen = new Set();
+    const deduped = [];
+    for (const item of flat) {
+      if (!seen.has(item.name)) {
+        seen.add(item.name);
+        deduped.push(item);
+      }
+    }
+
+    this.items = deduped;
+    this.isCompound = true;
+
+    this.name = deduped.map(i => i.name).sort().join("+");
+    this.displayName = deduped.map(i => i.displayName).join(" and ");
+    this.owned = deduped.length > 0 && deduped.every(item => item.owned);
+    this.isEvent = false;
+  }
+}
+
+class Clause {
+  /**
+   * Constructs a Clause with the given items.
+   * @param {Array} items - The items in this clause.
+   */
+  constructor(items = []) {
+    this.items = items;
+  }
+
+  /**
+   * IDEMPOTENT LAW (OR): A + A = A.
+   *
+   * Adds item only if no item with the same name is already present.
+   * @param {RequirementItem|CompoundItem} item - The item to add.
+   */
+  addItem(item) {
+    if (!this.items.some(i => i.name === item.name)) {
+      this.items.push(item);
+    }
+  }
+
+  /**
+   * Returns a shallow copy of this clause.
+   * @returns {Clause} A shallow clone of this clause.
+   */
+  clone() {
+    return new Clause([...this.items]);
+  }
+
+  /**
+   * Returns true if this clause has no items.
+   * @returns {boolean} True if there are no items in this clause.
+   */
+  isEmpty() {
+    return this.items.length === 0;
+  }
+
+  /**
+   * ANNIHILATION LAW (OR): A + 1 = 1.
+   *
+   * Returns true if any item is owned, or the clause is empty (vacuously true).
+   * @returns {boolean} True if the clause is satisfied.
+   */
+  isSatisfied() {
+    return this.items.length === 0 || this.items.some(item => item.owned);
+  }
+
+  /**
+   * Adds all items from `other` into this clause, deduplicating via addItem.
+   * @param {Clause} other - The clause whose items will be merged in.
+   */
+  merge(other) {
+    for (const item of other.items) {
+      this.addItem(item);
+    }
+  }
+}
+
+class Expression {
+  /**
+   * Constructs an Expression with the given clauses.
+   * @param {Array} clauses - The clauses in this expression.
+   */
+  constructor(clauses = []) {
+    this.clauses = clauses;
+  }
+
+  /**
+   * Appends a non-empty clause to this expression.
+   * @param {Clause} clause - The clause to add.
+   */
+  addClause(clause) {
+    if (!clause.isEmpty()) {
+      this.clauses.push(clause);
+    }
+  }
+
+  /**
+   * Returns a deep copy of this expression.
+   * @returns {Expression} A deep clone of this expression.
+   */
+  clone() {
+    return new Expression(this.clauses.map(clause => clause.clone()));
+  }
+
+  /**
+   * Returns true if this expression has no clauses (vacuously satisfied).
+   * @returns {boolean} True if there are no clauses.
+   */
+  isEmpty() {
+    return this.clauses.length === 0;
+  }
+
+  /**
+   * ANNIHILATION LAW (AND): A · 0 = 0.
+   *
+   * Returns true if any clause consists entirely of false items, making the expression unsatisfiable.
+   * @returns {boolean} True if the expression is impossible to satisfy.
+   */
+  isImpossible() {
+    return this.clauses.some(
+      clause =>
+        clause.items.length > 0 &&
+        clause.items.every(item => item.name === "__false__")
+    );
+  }
+
+  /**
+   * Returns true if all clauses are satisfied.
+   * @returns {boolean} True if every clause in this expression is satisfied.
+   */
+  isSatisfied() {
+    return this.clauses.every(clause => clause.isSatisfied());
+  }
+
+  /**
+   * Adds all clauses from `other` into this expression.
+   * @param {Expression} other - The expression whose clauses will be merged in.
+   */
+  merge(other) {
+    for (const clause of other.clauses) {
+      this.addClause(clause);
+    }
+  }
+
+  /**
+   * Simplifies the expression by applying Boolean algebra simplification laws.
+   */
+  simplify() {
+    // ANNIHILATION LAW (AND): A · 0 = 0
+    // If any clause contains ONLY false items, the entire expression is impossible.
+    // Must check before removing false items, otherwise empty clauses are treated as satisfied.
+    const hasImpossibleClause = this.clauses.some(
+      clause => clause.items.length > 0 && clause.items.every(item => item.name === "__false__")
+    );
+    if (hasImpossibleClause) {
+      this.clauses = [new Clause([new RequirementItem("__false__", "false", false)])];
+      return;
+    }
+
+    // IDENTITY LAW (OR): A + 0 = A
+    // Remove false items from each clause.
+    for (const clause of this.clauses) {
+      clause.items = clause.items.filter(item => item.name !== "__false__");
+    }
+
+    // IDENTITY LAW (AND): A · 1 = A
+    // Remove satisfied clauses.
+    this.clauses = this.clauses.filter(clause => !clause.isSatisfied());
+
+    // IDEMPOTENT LAW (OR): A + A = A
+    // Remove duplicate items within each clause. Also remove progressive item redundancy.
+    for (const clause of this.clauses) {
+      const seen = new Set();
+      clause.items = clause.items.filter(item => {
+        if (seen.has(item.name)) {
+          return false;
+        }
+        seen.add(item.name);
+        return true;
+      });
+
+      // For progressive items in an OR context, keep only the lowest count for each base item
+      if (clause.items.length > 1) {
+        const baseNameMinCount = new Map();
+        for (const item of clause.items) {
+          if (item.isCompound) { continue; }
+          const { baseName, count } = parseCountedItem(item.name);
+          const existing = baseNameMinCount.get(baseName);
+          if (existing === undefined || count < existing) {
+            baseNameMinCount.set(baseName, count);
+          }
+        }
+
+        clause.items = clause.items.filter(item => {
+          if (item.isCompound) { return true; }
+          const { baseName, count } = parseCountedItem(item.name);
+          return count <= baseNameMinCount.get(baseName);
+        });
+      }
+    }
+
+    // ABSORPTION LAW (OR): A + (A · B) = A
+    // Within each clause, if item A exists and (A · B) exists, remove (A · B) since A alone is sufficient.
+    for (const clause of this.clauses) {
+      clause.items = simplifyOrBySubset(clause.items);
+    }
+
+    // DISTRIBUTIVE LAW: (A · B) + (A · C) = A · (B + C)
+    // Factor out common items from OR options within a clause.
+    const newClauses = [];
+    for (const clause of this.clauses) {
+      if (clause.items.length > 1) {
+        const { factored, remaining } = factorCommonFromOrOptions(clause.items);
+        // Add factored items as separate AND clauses
+        for (const item of factored) {
+          newClauses.push(new Clause([item]));
+        }
+
+        // Keep remaining items as the OR clause
+        if (remaining.length > 0) {
+          newClauses.push(new Clause(remaining));
+        }
+      } else {
+        newClauses.push(clause);
+      }
+    }
+    this.clauses = newClauses;
+
+    // IDEMPOTENT LAW (AND): A · A = A
+    // Remove duplicate clauses.
+    const seenKeys = new Set();
+    this.clauses = this.clauses.filter(clause => {
+      const key = clause.items.map(i => i.name).sort().join("|");
+      if (seenKeys.has(key)) {
+        return false;
+      }
+      seenKeys.add(key);
+      return true;
+    });
+
+    // ABSORPTION LAW (AND): A · (A + B) = A
+    // When clause I implies clause J (every way to satisfy I also satisfies J), J is redundant.
+    // Handles the classic case ([A] makes [A, B] redundant) and progressive items ([Hookshot x2] implies [Hookshot x1]).
+    {
+      const progressiveAbsorbed = new Set();
+      for (let i = 0; i < this.clauses.length; i++) {
+        for (let j = i + 1; j < this.clauses.length; j++) {
+          if (progressiveAbsorbed.has(i) || progressiveAbsorbed.has(j)) { continue; }
+          const ci = this.clauses[i];
+          const cj = this.clauses[j];
+
+          // Check if I implies J: every item in I maps to an item in J with same base name and <= count
+          const iImpliesJ = ci.items.every(cItem => {
+            if (cItem.isCompound) {
+              return cj.items.some(oItem => oItem.name === cItem.name);
+            }
+            const { baseName: cBase, count: cCount } = parseCountedItem(cItem.name);
+            return cj.items.some(oItem => {
+              if (oItem.isCompound) { return false; }
+              const { baseName: oBase, count: oCount } = parseCountedItem(oItem.name);
+              return cBase === oBase && cCount >= oCount;
+            });
+          });
+
+          // Check if J implies I
+          const jImpliesI = cj.items.every(cItem => {
+            if (cItem.isCompound) {
+              return ci.items.some(oItem => oItem.name === cItem.name);
+            }
+            const { baseName: cBase, count: cCount } = parseCountedItem(cItem.name);
+            return ci.items.some(oItem => {
+              if (oItem.isCompound) { return false; }
+              const { baseName: oBase, count: oCount } = parseCountedItem(oItem.name);
+              return cBase === oBase && cCount >= oCount;
+            });
+          });
+
+          if (iImpliesJ) {
+            progressiveAbsorbed.add(j);
+          } else if (jImpliesI) {
+            progressiveAbsorbed.add(i);
+          }
+        }
+      }
+      if (progressiveAbsorbed.size > 0) {
+        this.clauses = this.clauses.filter((_, idx) => !progressiveAbsorbed.has(idx));
+      }
+    }
+  }
+}
+
+
+/**
+ * Returns a canonical impossible Expression containing a single false item.
+ * @returns {Expression} An unsatisfiable expression.
+ */
+function impossibleExpr() {
+  return new Expression([new Clause([new RequirementItem("__false__", "false", false)])]);
+}
+
+/**
+ * Combine two Expressions using proper OR with the Product-of-Sums distributive law.
+ * @param {Expression} expr1 - The first expression.
+ * @param {Expression} expr2 - The second expression.
+ * @returns {Expression} The OR combination of the two expressions.
+ */
+function orCombineExpressions(expr1, expr2) {
+  if (expr1.isEmpty() || expr1.isSatisfied() || expr2.isEmpty() || expr2.isSatisfied()) {
+    return new Expression();
+  }
+  if (expr1.isImpossible()) { return expr2; }
+  if (expr2.isImpossible()) { return expr1; }
+
+  const result = new Expression();
+  for (const clause1 of expr1.clauses) {
+    for (const clause2 of expr2.clauses) {
+      // Merge items from both clauses into one OR clause, deduplicating by name
+      const seen = new Set(clause1.items.map(i => i.name));
+      const mergedItems = [...clause1.items];
+      for (const item of clause2.items) {
+        if (!seen.has(item.name)) {
+          seen.add(item.name);
+          mergedItems.push(item);
+        }
+      }
+      result.addClause(new Clause(mergedItems));
+    }
+  }
+
+  result.simplify();
+  return result;
+}
+
+/**
+ * Combine an array of Expressions with OR.
+ *
+ * Returns an impossible Expression if the array is empty.
+ * @param {Array} exprs - Array of Expression objects to combine.
+ * @returns {Expression} The OR combination of all expressions.
+ */
+function combineWithOr(exprs) {
+  if (exprs.length === 0) {
+    return impossibleExpr();
+  }
+
+  let result = exprs[0];
+  for (let i = 1; i < exprs.length; i++) {
+    result = orCombineExpressions(result, exprs[i]);
+  }
+
+  return result;
+}
+
+/**
+ * DISTRIBUTIVE LAW: (A · B) + (A · C) = A · (B + C)
+ *
+ * Factor out common items from OR options.
+ * @param {Array} items - Array of items in an OR clause.
+ * @returns {{ factored: Array, remaining: Array }} Factored out items and remaining OR options.
+ */
+function factorCommonFromOrOptions(items) {
+  if (items.length <= 1) {
+    return { factored: [], remaining: items };
+  }
+
+  // Build a map of item names to their objects for each OR option
+  const optionItemMaps = items.map(item => {
+    const itemMap = new Map();
+    if (item.isCompound && item.items) {
+      for (const subItem of item.items) {
+        itemMap.set(subItem.name, subItem);
+      }
+    } else {
+      itemMap.set(item.name, item);
+    }
+    return itemMap;
+  });
+
+  // Find items that appear in ALL OR options
+  const firstOptionNames = [...optionItemMaps[0].keys()];
+  const commonNames = firstOptionNames.filter(name =>
+    optionItemMaps.every(map => map.has(name))
+  );
+
+  if (commonNames.length === 0) {
+    return { factored: [], remaining: items };
+  }
+
+  // Extract common items
+  const factored = commonNames.map(name => optionItemMaps[0].get(name));
+
+  // Build new OR options without the common items
+  const remaining = items.map((_item, index) => {
+    const itemMap = optionItemMaps[index];
+
+    // Remove common items from this option
+    const remainingItems = [];
+    for (const [name, subItem] of itemMap) {
+      if (!commonNames.includes(name)) {
+        remainingItems.push(subItem);
+      }
+    }
+
+    if (remainingItems.length === 0) {
+      // This option was entirely common items
+      return null;
+    }
+    if (remainingItems.length === 1) {
+      // Single item, no compound needed
+      return remainingItems[0];
+    }
+
+    // Multiple items remain, create a new compound
+    return new CompoundItem(remainingItems);
+  }).filter(item => item !== null);
+
+  // Deduplicate remaining items by name
+  const seenNames = new Set();
+  const dedupedRemaining = remaining.filter(item => {
+    if (seenNames.has(item.name)) {
+      return false;
+    }
+    seenNames.add(item.name);
+    return true;
+  });
+
+  return { factored, remaining: dedupedRemaining };
+}
+
+/**
+ * Parse a logic item name into its base name and required count.
+ * @param {string} itemName - Item name, optionally suffixed with ",N" for a count.
+ * @returns {{ baseName: string, count: number }} Parsed base name and count (defaults to 1).
+ */
+const parseCountedItem = memoize(function (itemName) {
+  const match = itemName.match(/^(.+),(\d+)$/);
+  if (match) {
+    return { baseName: match[1], count: parseInt(match[2], 10) };
+  }
+  return { baseName: itemName, count: 1 };
+});
+
+/**
+ * Return true if requirement set A is a subset of requirement set B.
+ * @param {Map} reqsA - Requirement map from item base name to count.
+ * @param {Map} reqsB - Requirement map from item base name to count.
+ * @returns {boolean} True if reqsA is a subset of reqsB.
+ */
+function isSubset(reqsA, reqsB) {
+  // A is a subset of B if:
+  // - Every item in A is also in B
+  // - For counted items, A's count <= B's count
+  for (const [baseName, countA] of reqsA) {
+    const countB = reqsB.get(baseName);
+    if (countB === undefined || countA > countB) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Return the requirement set for an item as a map from base name to count.
+ *
+ * For simple RequirementItems, returns a single-entry map.
+ * For CompoundItems (which use .items), collects requirements from all sub-items.
+ * @param {RequirementItem|CompoundItem} item - The item to get requirements for.
+ * @returns {Map} Map from item base name to required count.
+ */
+function getRequirementSet(item) {
+  const reqs = new Map();
+
+  if (item.isCompound) {
+    if (item.nestedOr && item.nestedOr.length > 0) {
+      // Use the full name as an opaque key so that a simple item covering only the base requirement cannot absorb this
+      // compound, since the compound's nestedOr part adds an additional constraint that the simple item lacks.
+      const { baseName, count } = parseCountedItem(item.name);
+      reqs.set(baseName, count);
+    } else {
+      // Plain AND compound: compare using the actual sub-item requirements so that
+      for (const subItem of item.items) {
+        const { baseName, count } = parseCountedItem(subItem.name);
+        const existing = reqs.get(baseName) || 0;
+        reqs.set(baseName, Math.max(existing, count));
+      }
+    }
+  } else {
+    const { baseName, count } = parseCountedItem(item.name);
+    reqs.set(baseName, count);
+  }
+
+  return reqs;
+}
+
+/**
+ * ABSORPTION LAW (OR): A + (A · B) = A
+ *
+ * Within an OR clause, if we have both a simple item A and a compound (A · B), the compound is redundant because
+ * satisfying A alone is sufficient.
+ * @param {Array} items - Array of items in an OR clause.
+ * @returns {Array} Simplified array with redundant items removed.
+ */
+function simplifyOrBySubset(items) {
+  if (items.length <= 1) {
+    return items;
+  }
+
+  // Get requirement sets for all items
+  const itemReqs = items.map(item => {
+    const reqs = getRequirementSet(item);
+    return {
+      item,
+      reqs,
+      size: reqs.size,
+      isCompound: item.isCompound
+    };
+  });
+
+  // Sort by size for efficient comparison
+  itemReqs.sort((a, b) => a.size - b.size);
+
+  // Mark items to keep (those that aren't supersets of another item)
+  const keep = new Array(items.length).fill(true);
+
+  for (let i = 0; i < itemReqs.length; i++) {
+    if (!keep[i]) { continue; }
+
+    for (let j = i + 1; j < itemReqs.length; j++) {
+      if (!keep[j]) { continue; }
+
+      // Check if itemReqs[i] is a subset of itemReqs[j]
+      // If so, itemReqs[j] is redundant
+      if (isSubset(itemReqs[i].reqs, itemReqs[j].reqs)) {
+        keep[j] = false;
+      }
+    }
+  }
+
+  return itemReqs.filter((_, i) => keep[i]).map(ir => ir.item);
+}
+
+/**
+ * Return the human-readable display name for a logic item name.
+ * @param {string} itemName - The canonical logic item name.
+ * @returns {string} The display name for tooltips.
+ */
+const getDisplayName = memoize(function (itemName) {
+  if (itemName in DISPLAY_NAMES) {
+    return DISPLAY_NAMES[itemName];
+  }
+  const name = itemName.replace(/_/g, " ");
+
+  // Reorder "Small Key <Dungeon>" to "<Dungeon> Small Key" and "Boss Key <Dungeon>" to "<Dungeon> Boss Key"
+  const keyMatch = name.match(/^(Small Key|Boss Key) (.+)$/);
+  if (keyMatch) {
+    return `${keyMatch[2]} ${keyMatch[1]}`;
+  }
+  return name;
+});
+
+export {
+  Clause, combineWithOr, CompoundItem, Expression, getDisplayName, impossibleExpr, orCombineExpressions, parseCountedItem, RequirementItem, simplifyOrBySubset
+};

--- a/src/utils/expression-data.test.js
+++ b/src/utils/expression-data.test.js
@@ -1,0 +1,778 @@
+import {
+  Clause,
+  combineWithOr,
+  CompoundItem,
+  Expression,
+  getDisplayName,
+  impossibleExpr, orCombineExpressions,
+  parseCountedItem,
+  RequirementItem,
+  simplifyOrBySubset,
+} from "./expression-data";
+
+
+// Convenience factories
+const ri = (name, owned = false, isEvent = false) =>
+  new RequirementItem(name, name, owned, isEvent);
+const ownedRi = (name) => ri(name, true);
+const falseItem = () => ri("__false__");
+
+
+describe("RequirementItem", () => {
+  test("stores name, displayName, owned, and isEvent", () => {
+    const item = new RequirementItem("Bow", "Fairy Bow", true, true);
+    expect(item.name).toBe("Bow");
+    expect(item.displayName).toBe("Fairy Bow");
+    expect(item.owned).toBe(true);
+    expect(item.isEvent).toBe(true);
+  });
+
+  test("isEvent defaults to false", () => {
+    const item = new RequirementItem("X", "X", false);
+    expect(item.isEvent).toBe(false);
+  });
+});
+
+
+describe("CompoundItem", () => {
+  test("stores items with isCompound=true and isEvent=false", () => {
+    const c = new CompoundItem([ri("A"), ri("B")]);
+    expect(c.isCompound).toBe(true);
+    expect(c.isEvent).toBe(false);
+    expect(c.items).toHaveLength(2);
+  });
+
+  test("name is sorted sub-item names joined with +", () => {
+    const c = new CompoundItem([ri("B"), ri("A")]);
+    expect(c.name).toBe("A+B");
+  });
+
+  test("displayName is sub-item displayNames joined with ' and '", () => {
+    const a = new RequirementItem("A", "Alpha", false);
+    const b = new RequirementItem("B", "Beta", false);
+    const c = new CompoundItem([a, b]);
+    expect(c.displayName).toBe("Alpha and Beta");
+  });
+
+  test("owned is true when all sub-items are owned", () => {
+    const c = new CompoundItem([ownedRi("A"), ownedRi("B")]);
+    expect(c.owned).toBe(true);
+  });
+
+  test("owned is false when any sub-item is not owned", () => {
+    const c = new CompoundItem([ownedRi("A"), ri("B")]);
+    expect(c.owned).toBe(false);
+  });
+
+  test("owned is false for empty items array", () => {
+    const c = new CompoundItem([]);
+    expect(c.owned).toBe(false);
+  });
+
+  test("flattens nested CompoundItems without nestedOr", () => {
+    const inner = new CompoundItem([ri("A"), ri("B")]);
+    const outer = new CompoundItem([inner, ri("C")]);
+    expect(outer.items).toHaveLength(3);
+    expect(outer.items.map(i => i.name).sort()).toEqual(["A", "B", "C"]);
+  });
+
+  test("does NOT flatten CompoundItems with nestedOr set", () => {
+    const inner = new CompoundItem([ri("A"), ri("B")]);
+    inner.nestedOr = [ri("X")];
+    const outer = new CompoundItem([inner, ri("C")]);
+    expect(outer.items).toHaveLength(2);
+    expect(outer.items[0].isCompound).toBe(true);
+  });
+
+  test("deduplicates items by name, keeping first occurrence", () => {
+    const a1 = ri("A", false);
+    const a2 = ri("A", true);
+    const c = new CompoundItem([a1, a2, ri("B")]);
+    expect(c.items).toHaveLength(2);
+    expect(c.items.find(i => i.name === "A").owned).toBe(false);
+  });
+
+  test("flattening and deduplication combined", () => {
+    const inner = new CompoundItem([ri("A"), ri("B")]);
+    const outer = new CompoundItem([inner, ri("A"), ri("C")]);
+    expect(outer.items).toHaveLength(3);
+    expect(outer.items.map(i => i.name).sort()).toEqual(["A", "B", "C"]);
+  });
+});
+
+
+describe("Clause", () => {
+  describe("constructor", () => {
+    test("stores items", () => {
+      const items = [ri("A"), ri("B")];
+      const c = new Clause(items);
+      expect(c.items).toHaveLength(2);
+    });
+
+    test("defaults to empty items array", () => {
+      const c = new Clause();
+      expect(c.items).toEqual([]);
+    });
+  });
+
+  describe("addItem", () => {
+    test("adds item to empty clause", () => {
+      const c = new Clause();
+      c.addItem(ri("A"));
+      expect(c.items).toHaveLength(1);
+    });
+
+    test("adds item alongside existing items", () => {
+      const c = new Clause([ri("A")]);
+      c.addItem(ri("B"));
+      expect(c.items).toHaveLength(2);
+    });
+
+    test("rejects duplicate name (idempotent)", () => {
+      const c = new Clause([ri("A")]);
+      c.addItem(ri("A"));
+      expect(c.items).toHaveLength(1);
+    });
+  });
+
+  describe("clone", () => {
+    test("returns a new Clause with same items", () => {
+      const original = new Clause([ri("A"), ri("B")]);
+      const cloned = original.clone();
+      expect(cloned).not.toBe(original);
+      expect(cloned.items).toHaveLength(2);
+      expect(cloned.items[0].name).toBe("A");
+    });
+
+    test("modifying clone does not affect original", () => {
+      const original = new Clause([ri("A")]);
+      const cloned = original.clone();
+      cloned.addItem(ri("B"));
+      expect(original.items).toHaveLength(1);
+      expect(cloned.items).toHaveLength(2);
+    });
+  });
+
+  describe("isEmpty", () => {
+    test("returns true for no items", () => {
+      expect(new Clause().isEmpty()).toBe(true);
+    });
+
+    test("returns false when items exist", () => {
+      expect(new Clause([ri("A")]).isEmpty()).toBe(false);
+    });
+  });
+
+  describe("isSatisfied", () => {
+    test("empty clause is satisfied (vacuous truth)", () => {
+      expect(new Clause().isSatisfied()).toBe(true);
+    });
+
+    test("satisfied when any item is owned", () => {
+      const c = new Clause([ri("A"), ownedRi("B")]);
+      expect(c.isSatisfied()).toBe(true);
+    });
+
+    test("not satisfied when no item is owned", () => {
+      const c = new Clause([ri("A"), ri("B")]);
+      expect(c.isSatisfied()).toBe(false);
+    });
+  });
+
+  describe("merge", () => {
+    test("merges items from other clause", () => {
+      const c1 = new Clause([ri("A")]);
+      const c2 = new Clause([ri("B")]);
+      c1.merge(c2);
+      expect(c1.items).toHaveLength(2);
+    });
+
+    test("deduplicates during merge", () => {
+      const c1 = new Clause([ri("A")]);
+      const c2 = new Clause([ri("A"), ri("B")]);
+      c1.merge(c2);
+      expect(c1.items).toHaveLength(2);
+    });
+  });
+});
+
+
+describe("Expression", () => {
+  describe("constructor", () => {
+    test("stores clauses", () => {
+      const e = new Expression([new Clause([ri("A")])]);
+      expect(e.clauses).toHaveLength(1);
+    });
+
+    test("defaults to empty clauses array", () => {
+      expect(new Expression().clauses).toEqual([]);
+    });
+  });
+
+  describe("addClause", () => {
+    test("adds non-empty clause", () => {
+      const e = new Expression();
+      e.addClause(new Clause([ri("A")]));
+      expect(e.clauses).toHaveLength(1);
+    });
+
+    test("skips empty clause", () => {
+      const e = new Expression();
+      e.addClause(new Clause());
+      expect(e.clauses).toHaveLength(0);
+    });
+  });
+
+  describe("clone", () => {
+    test("returns deep copy independent of original", () => {
+      const original = new Expression([new Clause([ri("A")])]);
+      const cloned = original.clone();
+      expect(cloned).not.toBe(original);
+      expect(cloned.clauses[0]).not.toBe(original.clauses[0]);
+      cloned.clauses[0].addItem(ri("B"));
+      expect(original.clauses[0].items).toHaveLength(1);
+      expect(cloned.clauses[0].items).toHaveLength(2);
+    });
+  });
+
+  describe("isEmpty", () => {
+    test("returns true for no clauses", () => {
+      expect(new Expression().isEmpty()).toBe(true);
+    });
+
+    test("returns false when clauses exist", () => {
+      expect(new Expression([new Clause([ri("A")])]).isEmpty()).toBe(false);
+    });
+  });
+
+  describe("isImpossible", () => {
+    test("returns true when clause has only __false__ items", () => {
+      const e = new Expression([new Clause([falseItem()])]);
+      expect(e.isImpossible()).toBe(true);
+    });
+
+    test("returns true when ANY clause is all-false", () => {
+      const e = new Expression([
+        new Clause([ri("A")]),
+        new Clause([falseItem()]),
+      ]);
+      expect(e.isImpossible()).toBe(true);
+    });
+
+    test("returns false for normal items", () => {
+      const e = new Expression([new Clause([ri("A")])]);
+      expect(e.isImpossible()).toBe(false);
+    });
+
+    test("returns false for empty expression", () => {
+      expect(new Expression().isImpossible()).toBe(false);
+    });
+
+    test("returns false when clause has false AND valid items", () => {
+      const e = new Expression([new Clause([falseItem(), ri("A")])]);
+      expect(e.isImpossible()).toBe(false);
+    });
+  });
+
+  describe("isSatisfied", () => {
+    test("returns true when all clauses satisfied", () => {
+      const e = new Expression([
+        new Clause([ownedRi("A")]),
+        new Clause([ownedRi("B")]),
+      ]);
+      expect(e.isSatisfied()).toBe(true);
+    });
+
+    test("returns false when any clause is unsatisfied", () => {
+      const e = new Expression([
+        new Clause([ownedRi("A")]),
+        new Clause([ri("B")]),
+      ]);
+      expect(e.isSatisfied()).toBe(false);
+    });
+
+    test("returns true for empty expression", () => {
+      expect(new Expression().isSatisfied()).toBe(true);
+    });
+  });
+
+  describe("merge", () => {
+    test("merges clauses from other expression", () => {
+      const e1 = new Expression([new Clause([ri("A")])]);
+      const e2 = new Expression([new Clause([ri("B")])]);
+      e1.merge(e2);
+      expect(e1.clauses).toHaveLength(2);
+    });
+
+    test("skips empty clauses during merge", () => {
+      const e1 = new Expression();
+      const e2 = new Expression([new Clause(), new Clause([ri("A")])]);
+      e1.merge(e2);
+      expect(e1.clauses).toHaveLength(1);
+    });
+  });
+});
+
+
+describe("Expression.simplify", () => {
+  describe("ANNIHILATION (AND): A * 0 = 0", () => {
+    test("collapses to impossible when clause has only false items", () => {
+      const e = new Expression([new Clause([falseItem()])]);
+      e.simplify();
+      expect(e.isImpossible()).toBe(true);
+      expect(e.clauses).toHaveLength(1);
+    });
+
+    test("collapses even with other valid clauses present", () => {
+      const e = new Expression([
+        new Clause([ri("A")]),
+        new Clause([falseItem()]),
+      ]);
+      e.simplify();
+      expect(e.isImpossible()).toBe(true);
+    });
+
+    test("[__false__] detected as impossible, not simplified to empty", () => {
+      const e = new Expression([new Clause([falseItem()])]);
+      e.simplify();
+      expect(e.isSatisfied()).toBe(false);
+      expect(e.isImpossible()).toBe(true);
+    });
+  });
+
+  describe("IDENTITY (OR): A + 0 = A", () => {
+    test("removes false items from clauses", () => {
+      const e = new Expression([new Clause([ri("A"), falseItem()])]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("A");
+    });
+
+    test("leaves non-false items unchanged", () => {
+      const e = new Expression([new Clause([ri("A"), ri("B")])]);
+      e.simplify();
+      expect(e.clauses[0].items).toHaveLength(2);
+    });
+  });
+
+  describe("IDENTITY (AND): A * 1 = A", () => {
+    test("removes clauses with owned items (satisfied)", () => {
+      const e = new Expression([
+        new Clause([ri("A")]),
+        new Clause([ownedRi("B")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("A");
+    });
+
+    test("removes empty clauses after false item removal", () => {
+      const e = new Expression([
+        new Clause([falseItem(), ownedRi("X")]),
+        new Clause([ri("A")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("A");
+    });
+
+    test("keeps unsatisfied clauses", () => {
+      const e = new Expression([new Clause([ri("A")])]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+    });
+  });
+
+  describe("IDEMPOTENT (OR): A + A = A", () => {
+    test("removes duplicate items within a clause", () => {
+      const e = new Expression([new Clause([ri("A"), ri("A"), ri("B")])]);
+      e.simplify();
+      expect(e.clauses[0].items).toHaveLength(2);
+    });
+
+    test("keeps lowest count for progressive items", () => {
+      const hook1 = new RequirementItem("Progressive_Hookshot,1", "Hookshot", false);
+      const hook2 = new RequirementItem("Progressive_Hookshot,2", "Longshot", false);
+      const e = new Expression([new Clause([hook2, hook1])]);
+      e.simplify();
+      expect(e.clauses[0].items).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("Progressive_Hookshot,1");
+    });
+
+    test("single-item clause skips progressive reduction", () => {
+      const hook2 = new RequirementItem("Progressive_Hookshot,2", "Longshot", false);
+      const e = new Expression([new Clause([hook2])]);
+      e.simplify();
+      expect(e.clauses[0].items[0].name).toBe("Progressive_Hookshot,2");
+    });
+
+    test("skips compound items during progressive dedup", () => {
+      const compound = new CompoundItem([ri("A"), ri("B")]);
+      const e = new Expression([new Clause([compound, ri("C"), ri("C")])]);
+      e.simplify();
+      // Compound kept, duplicate C removed
+      const names = e.clauses[0].items.map(i => i.name);
+      expect(names).toContain("A+B");
+      expect(names).toContain("C");
+      expect(e.clauses[0].items).toHaveLength(2);
+    });
+  });
+
+  describe("ABSORPTION (OR): A + (A * B) = A", () => {
+    test("removes compound when simple item exists in same clause", () => {
+      const compound = new CompoundItem([ri("A"), ri("B")]);
+      const e = new Expression([new Clause([ri("A"), compound])]);
+      e.simplify();
+      expect(e.clauses[0].items).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("A");
+    });
+
+    test("keeps compound when no simpler item exists", () => {
+      const compound = new CompoundItem([ri("A"), ri("B")]);
+      const e = new Expression([new Clause([compound, ri("C")])]);
+      e.simplify();
+      expect(e.clauses[0].items).toHaveLength(2);
+    });
+
+    test("handles counted items: lower count absorbs higher compound", () => {
+      const hook1 = new RequirementItem("Progressive_Hookshot,1", "Hookshot", false);
+      const hook2 = new RequirementItem("Progressive_Hookshot,2", "Longshot", false);
+      const compound = new CompoundItem([hook2, ri("Bow")]);
+      const e = new Expression([new Clause([hook1, compound])]);
+      e.simplify();
+      expect(e.clauses[0].items).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("Progressive_Hookshot,1");
+    });
+  });
+
+  describe("DISTRIBUTIVE: (A*B) + (A*C) = A * (B+C)", () => {
+    test("factors common item from compound OR options", () => {
+      const ab = new CompoundItem([ri("A"), ri("B")]);
+      const ac = new CompoundItem([ri("A"), ri("C")]);
+      const e = new Expression([new Clause([ab, ac])]);
+      e.simplify();
+      const singleItemClauses = e.clauses.filter(c => c.items.length === 1);
+      const singleNames = singleItemClauses.map(c => c.items[0].name);
+      expect(singleNames).toContain("A");
+    });
+
+    test("no factoring when nothing is common", () => {
+      const ab = new CompoundItem([ri("A"), ri("B")]);
+      const cd = new CompoundItem([ri("C"), ri("D")]);
+      const e = new Expression([new Clause([ab, cd])]);
+      e.simplify();
+      expect(e.clauses.some(c => c.items.length === 2)).toBe(true);
+    });
+
+    test("single (non-compound) items are not factored", () => {
+      const e = new Expression([new Clause([ri("A"), ri("B")])]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items).toHaveLength(2);
+    });
+  });
+
+  describe("IDEMPOTENT (AND): A * A = A", () => {
+    test("removes duplicate clauses", () => {
+      const e = new Expression([
+        new Clause([ri("A")]),
+        new Clause([ri("A")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+    });
+
+    test("clause equality is order-independent", () => {
+      const e = new Expression([
+        new Clause([ri("A"), ri("B")]),
+        new Clause([ri("B"), ri("A")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+    });
+  });
+
+  describe("ABSORPTION (AND): A * (A + B) = A", () => {
+    test("removes redundant superset clause", () => {
+      const e = new Expression([
+        new Clause([ri("A")]),
+        new Clause([ri("A"), ri("B")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("A");
+    });
+
+    test("progressive items: higher count clause absorbs lower count clause", () => {
+      const hook1 = new RequirementItem("Progressive_Hookshot,1", "Hookshot", false);
+      const hook2 = new RequirementItem("Progressive_Hookshot,2", "Longshot", false);
+      const e = new Expression([
+        new Clause([hook2]),
+        new Clause([hook1, ri("Bow")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("Progressive_Hookshot,2");
+    });
+
+    test("does not absorb when items differ", () => {
+      const e = new Expression([
+        new Clause([ri("A")]),
+        new Clause([ri("B")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(2);
+    });
+
+    test("bidirectional: smaller clause absorbs regardless of order", () => {
+      const e = new Expression([
+        new Clause([ri("A"), ri("B")]),
+        new Clause([ri("A")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items).toHaveLength(1);
+    });
+  });
+
+  describe("integration", () => {
+    test("applies multiple laws in sequence", () => {
+      const e = new Expression([
+        new Clause([ri("A"), falseItem()]),
+        new Clause([ri("A"), ri("B")]),
+        new Clause([ownedRi("X")]),
+      ]);
+      e.simplify();
+      expect(e.clauses).toHaveLength(1);
+      expect(e.clauses[0].items[0].name).toBe("A");
+    });
+
+    test("empty expression stays empty", () => {
+      const e = new Expression();
+      e.simplify();
+      expect(e.isEmpty()).toBe(true);
+    });
+
+    test("all-satisfied clauses result in empty expression", () => {
+      const e = new Expression([
+        new Clause([ownedRi("A")]),
+        new Clause([ownedRi("B")]),
+      ]);
+      e.simplify();
+      expect(e.isEmpty()).toBe(true);
+    });
+  });
+});
+
+
+describe("impossibleExpr", () => {
+  test("returns expression with single false clause", () => {
+    const e = impossibleExpr();
+    expect(e.clauses).toHaveLength(1);
+    expect(e.clauses[0].items).toHaveLength(1);
+    expect(e.clauses[0].items[0].name).toBe("__false__");
+  });
+
+  test("isImpossible returns true", () => {
+    expect(impossibleExpr().isImpossible()).toBe(true);
+  });
+
+  test("isSatisfied returns false", () => {
+    expect(impossibleExpr().isSatisfied()).toBe(false);
+  });
+});
+
+
+describe("orCombineExpressions", () => {
+  test("returns empty when expr1 is empty", () => {
+    const result = orCombineExpressions(new Expression(), new Expression([new Clause([ri("A")])]));
+    expect(result.isEmpty()).toBe(true);
+  });
+
+  test("returns expr2 when expr1 is impossible", () => {
+    const expr2 = new Expression([new Clause([ri("A")])]);
+    const result = orCombineExpressions(impossibleExpr(), expr2);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items[0].name).toBe("A");
+  });
+
+  test("returns expr1 when expr2 is impossible", () => {
+    const expr1 = new Expression([new Clause([ri("A")])]);
+    const result = orCombineExpressions(expr1, impossibleExpr());
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items[0].name).toBe("A");
+  });
+
+  test("combines single-clause expressions into OR", () => {
+    const e1 = new Expression([new Clause([ri("A")])]);
+    const e2 = new Expression([new Clause([ri("B")])]);
+    const result = orCombineExpressions(e1, e2);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items).toHaveLength(2);
+  });
+
+  test("distributes multi-clause expressions (product-of-sums)", () => {
+    const e1 = new Expression([new Clause([ri("A")]), new Clause([ri("B")])]);
+    const e2 = new Expression([new Clause([ri("C")]), new Clause([ri("D")])]);
+    const result = orCombineExpressions(e1, e2);
+    expect(result.clauses.length).toBeGreaterThan(0);
+  });
+
+  test("both impossible returns impossible", () => {
+    const result = orCombineExpressions(impossibleExpr(), impossibleExpr());
+    expect(result.isImpossible()).toBe(true);
+  });
+
+  test("deduplicates and simplifies result", () => {
+    const e1 = new Expression([new Clause([ri("A")])]);
+    const e2 = new Expression([new Clause([ri("A")])]);
+    const result = orCombineExpressions(e1, e2);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items[0].name).toBe("A");
+  });
+});
+
+
+describe("combineWithOr", () => {
+  test("returns impossible for empty array", () => {
+    expect(combineWithOr([]).isImpossible()).toBe(true);
+  });
+
+  test("returns single expression unchanged", () => {
+    const e = new Expression([new Clause([ri("A")])]);
+    const result = combineWithOr([e]);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items[0].name).toBe("A");
+  });
+
+  test("combines two expressions with OR", () => {
+    const e1 = new Expression([new Clause([ri("A")])]);
+    const e2 = new Expression([new Clause([ri("B")])]);
+    const result = combineWithOr([e1, e2]);
+    expect(result.clauses).toHaveLength(1);
+    expect(result.clauses[0].items).toHaveLength(2);
+  });
+
+  test("mix of impossible and valid: valid survives", () => {
+    const valid = new Expression([new Clause([ri("A")])]);
+    const result = combineWithOr([impossibleExpr(), valid]);
+    expect(result.isImpossible()).toBe(false);
+    expect(result.clauses[0].items[0].name).toBe("A");
+  });
+});
+
+
+describe("parseCountedItem", () => {
+  test("parses item with count", () => {
+    const { baseName, count } = parseCountedItem("Progressive_Hookshot,2");
+    expect(baseName).toBe("Progressive_Hookshot");
+    expect(count).toBe(2);
+  });
+
+  test("parses item without count", () => {
+    const { baseName, count } = parseCountedItem("Bow");
+    expect(baseName).toBe("Bow");
+    expect(count).toBe(1);
+  });
+
+  test("handles explicit ,1 suffix", () => {
+    const { baseName, count } = parseCountedItem("Bow,1");
+    expect(baseName).toBe("Bow");
+    expect(count).toBe(1);
+  });
+
+  test("handles underscored names with count", () => {
+    const { baseName, count } = parseCountedItem("Progressive_Strength_Upgrade,3");
+    expect(baseName).toBe("Progressive_Strength_Upgrade");
+    expect(count).toBe(3);
+  });
+
+  test("memoizes results (same reference on repeat call)", () => {
+    const r1 = parseCountedItem("Bow");
+    const r2 = parseCountedItem("Bow");
+    expect(r1).toBe(r2);
+  });
+});
+
+
+describe("getDisplayName", () => {
+  test("returns mapped name for known items", () => {
+    expect(getDisplayName("Progressive_Hookshot")).toBe("Hookshot");
+    expect(getDisplayName("Bow")).toBe("Bow");
+    expect(getDisplayName("Bomb_Bag")).toBe("Bombs");
+  });
+
+  test("replaces underscores with spaces for unknown items", () => {
+    expect(getDisplayName("Unknown_Item")).toBe("Unknown Item");
+  });
+
+  test("reorders Small Key items", () => {
+    expect(getDisplayName("Small_Key_Forest_Temple")).toBe("Forest Temple Small Key");
+  });
+
+  test("reorders Boss Key items", () => {
+    expect(getDisplayName("Boss_Key_Shadow_Temple")).toBe("Shadow Temple Boss Key");
+  });
+
+  test("returns correct display name for songs", () => {
+    expect(getDisplayName("Zeldas_Lullaby")).toBe("Zelda's Lullaby");
+    expect(getDisplayName("Eponas_Song")).toBe("Epona's Song");
+  });
+
+  test("returns correct display name for equipment", () => {
+    expect(getDisplayName("Gerudo_Membership_Card")).toBe("Gerudo Card");
+  });
+
+  test("handles single word item", () => {
+    expect(getDisplayName("Boomerang")).toBe("Boomerang");
+  });
+
+  test("memoizes results", () => {
+    const r1 = getDisplayName("Dins_Fire");
+    const r2 = getDisplayName("Dins_Fire");
+    expect(r1).toBe(r2);
+    expect(r1).toBe("Din's Fire");
+  });
+});
+
+
+describe("simplifyOrBySubset", () => {
+  test("returns single item unchanged", () => {
+    const items = [ri("A")];
+    expect(simplifyOrBySubset(items)).toHaveLength(1);
+  });
+
+  test("returns empty array unchanged", () => {
+    expect(simplifyOrBySubset([])).toHaveLength(0);
+  });
+
+  test("removes compound superset of simple item", () => {
+    const simple = ri("A");
+    const compound = new CompoundItem([ri("A"), ri("B")]);
+    const result = simplifyOrBySubset([simple, compound]);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("A");
+  });
+
+  test("keeps unrelated items", () => {
+    const result = simplifyOrBySubset([ri("A"), ri("B")]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles multiple absorptions", () => {
+    const a = ri("A");
+    const ab = new CompoundItem([ri("A"), ri("B")]);
+    const ac = new CompoundItem([ri("A"), ri("C")]);
+    const result = simplifyOrBySubset([a, ab, ac]);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("A");
+  });
+
+  test("compound with nestedOr uses opaque name (not absorbed by base item)", () => {
+    const compound = new CompoundItem([ri("A"), ri("B")]);
+    compound.nestedOr = [ri("X")];
+    const result = simplifyOrBySubset([ri("A"), compound]);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/utils/locations.js
+++ b/src/utils/locations.js
@@ -45,10 +45,10 @@ class Locations {
       overworld: new Map(),
     };
 
-    this.regionMap = new Map();
+    this.regionMap = {};
     _.forEach(HINT_REGIONS, (hintRegionData, hintRegionName) => {
       _.forEach(hintRegionData, regionName => {
-        _.set(this.regionMap, regionName, hintRegionName);
+        this.regionMap[regionName] = hintRegionName;
       });
     });
 
@@ -317,6 +317,36 @@ class Locations {
     }
 
     return null;
+  }
+
+  static getLocationsByVanillaItem(vanillaItemName) {
+    const results = [];
+
+    // Check overworld
+    for (const regionData of Object.values(this.locations.overworld)) {
+      for (const location of Object.values(regionData)) {
+        if (location.vanillaItem === vanillaItemName) {
+          results.push(location);
+        }
+      }
+    }
+
+    // Check dungeons based on MQ settings
+    for (const dungeonName of DUNGEONS) {
+      const source = SettingsHelper.isMQDungeon(dungeonName)
+        ? this.locations.dungeon_mq[dungeonName]
+        : this.locations.dungeon[dungeonName];
+
+      if (source) {
+        for (const location of Object.values(source)) {
+          if (location.vanillaItem === vanillaItemName) {
+            results.push(location);
+          }
+        }
+      }
+    }
+
+    return results;
   }
 
   static getSkullsLocations() {
@@ -595,10 +625,7 @@ class Locations {
     // Ganon boss key
     else if (location.vanillaItem === "Boss Key (Ganons Castle)") {
       const shuffleGanonBosskey = SettingsHelper.getSetting("shuffle_ganon_bosskey");
-      if (shuffleGanonBosskey === "vanilla") {
-        return false;
-      }
-      return _.includes(["remove", "any_dungeon", "overworld", "keysanity", "regional"], shuffleGanonBosskey);
+      return shuffleGanonBosskey !== "vanilla";
     }
 
     // Dungeon Items

--- a/src/utils/logic-helper.js
+++ b/src/utils/logic-helper.js
@@ -24,6 +24,29 @@ const ADULT_TRADE_LOOKUP = Object.fromEntries(
   ])
 );
 
+// Map of setting names to item names for starting items.
+// Authoritative source — expression-converter delegates to getStartingItems().
+const STARTING_ITEM_SETTINGS = {
+  ocarina: "Ocarina",
+  deku_shield: "Deku_Shield",
+  hylian_shield: "Hylian_Shield",
+  mirror_shield: "Mirror_Shield",
+  kokiri_sword: "Kokiri_Sword",
+  master_sword: "Master_Sword",
+  biggoron_sword: "Biggoron_Sword",
+  goron_tunic: "Goron_Tunic",
+  zora_tunic: "Zora_Tunic",
+  iron_boots: "Iron_Boots",
+  hover_boots: "Hover_Boots",
+  zeldas_letter: "Zeldas_Letter",
+  weird_egg: "Weird_Egg",
+  stone_of_agony: "Stone_of_Agony",
+  gerudo_card: "Gerudo_Membership_Card",
+  deku_nut: "Deku_Nut",
+  deku_stick: "Deku_Stick",
+  rupee: "Rupee",
+};
+
 class LogicHelper {
   static BUILTIN_FUNCTIONS = {
     // source: State.py
@@ -238,6 +261,23 @@ class LogicHelper {
     this.memoizedFunctions = this._memoizeFunctions();
 
     return this.settings;
+  }
+
+  static getStartingItems() {
+    const items = {};
+    const startingLists = [
+      this.settings?.starting_inventory || [],
+      this.settings?.starting_equipment || [],
+    ];
+    for (const list of startingLists) {
+      for (const startingItem of list) {
+        const mappedName = STARTING_ITEM_SETTINGS[startingItem];
+        if (mappedName) {
+          items[mappedName] = (items[mappedName] || 0) + 1;
+        }
+      }
+    }
+    return items;
   }
 
   static updateItems(newItems) {

--- a/src/utils/rule-parser.js
+++ b/src/utils/rule-parser.js
@@ -1,6 +1,11 @@
 import { parse } from "acorn";
 import _ from "lodash";
 
+/**
+ * Parses a logic rule string into an AST node.
+ * @param {string} ruleString - The rule string.
+ * @returns {object} The parsed AST expression statement.
+ */
 export function parseRule(ruleString) {
   const rule = _.flow(
     _.trim,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,6 +3,11 @@ import { v4 as uuidv4 } from "uuid";
 import HINT_REGIONS_KEYWORDS from "../data/hint-regions-keywords.json";
 import HINT_REGIONS from "../data/hint-regions.json";
 
+/**
+ * Reads a File object as text.
+ * @param {File} file - The file to read.
+ * @returns {Promise<string>} The file contents as a string.
+ */
 export async function readFileAsText(file) {
   const result = await new Promise(resolve => {
     const fileReader = new FileReader();
@@ -13,10 +18,20 @@ export async function readFileAsText(file) {
   return result;
 }
 
+/**
+ * Generates a UUID without hyphens.
+ * @returns {string} A 32-character hex string.
+ */
 export function generateId() {
   return uuidv4().replace(/-/g, "");
 }
 
+/**
+ * Splits an array into chunks of the given size.
+ * @param {Array} arr - The array to split.
+ * @param {number} chunk - The chunk size.
+ * @returns {Array<Array>} Array of chunked sub-arrays.
+ */
 export function splitIntoChunk(arr, chunk) {
   const chunks = [];
   for (let i = 0; i < arr.length; i += chunk) {
@@ -26,15 +41,30 @@ export function splitIntoChunk(arr, chunk) {
   return chunks;
 }
 
+/**
+ * Splits a "name;base64data" string into its parts.
+ * @param {string} string - The combined name and base64 string.
+ * @returns {{name: string, file: string}} The separated name and file data.
+ */
 export function splitNameBase64(string) {
   const [name, file] = string.split(/;(.*)/s);
   return { name, file };
 }
 
+/**
+ * Checks if a string is a base64-encoded PNG data URI.
+ * @param {string} string - The string to test.
+ * @returns {Array|null} The match result, or null.
+ */
 export function isBase64(string) {
   return string.match(/data:image\/png;base64{1}.*/);
 }
 
+/**
+ * Rebuilds hint region mappings from logic files.
+ * @param {Array} files - Array of location file data.
+ * @returns {object} Map of hint region names to their sub-regions.
+ */
 export function updateHintRegionsJSON(files) {
   // Cleaning the regions before rebuilding ?
   const regions = Object.keys(HINT_REGIONS).reduce((accumulator, key) => {
@@ -61,7 +91,13 @@ export function updateHintRegionsJSON(files) {
   return regions;
 }
 
-export function duplicate(component, components, setComponent) {
+/**
+ * Duplicates a layout component with a new ID.
+ * @param {object} component - The component to duplicate.
+ * @param {Array} _components - The current components list (unused).
+ * @param {function(object): void} setComponent - Callback to set the new component.
+ */
+export function duplicate(component, _components, setComponent) {
   if (!component) { return; }
 
   setComponent({

--- a/src/versions/version-config.js
+++ b/src/versions/version-config.js
@@ -3,10 +3,20 @@ const BUNDLED_VERSIONS = new Set(["9.0.0", "8.3.0"]);
 const DEFAULT_OWNER = "OoTRandomizer";
 const FALLBACK_VERSION = "9.0.0";
 
+/**
+ * Checks if a version has bundled logic files.
+ * @param {string} version - The version string to check.
+ * @returns {boolean} True if the version is bundled.
+ */
 function isBundled(version) {
   return BUNDLED_VERSIONS.has(version);
 }
 
+/**
+ * Dynamically imports bundled logic files for a version.
+ * @param {string} version - The version string.
+ * @returns {Promise<object|null>} The bundle or null if not bundled.
+ */
 async function getBundledLogicFiles(version) {
   if (!isBundled(version)) {
     return null;
@@ -16,6 +26,11 @@ async function getBundledLogicFiles(version) {
   return bundle.default;
 }
 
+/**
+ * Parses a version string into owner and tag, supporting fork syntax.
+ * @param {string} version - The version string (e.g. "9.0.0" or "owner/tag").
+ * @returns {{owner: string, tag: string}} The parsed owner and tag.
+ */
 function parseVersion(version) {
   if (!version) {
     return { owner: DEFAULT_OWNER, tag: FALLBACK_VERSION };
@@ -31,14 +46,27 @@ function parseVersion(version) {
   return { owner: DEFAULT_OWNER, tag: version };
 }
 
+/**
+ * Returns the fallback version string.
+ * @returns {string} The fallback version.
+ */
 function getFallbackVersion() {
   return FALLBACK_VERSION;
 }
 
+/**
+ * Loads bundled logic files for the fallback version.
+ * @returns {Promise<object>} The fallback bundle.
+ */
 async function getFallbackLogicFiles() {
   return getBundledLogicFiles(FALLBACK_VERSION);
 }
 
+/**
+ * Normalizes a version string (strips "v" prefix, adds .0 patch if needed).
+ * @param {string} version - The raw version string.
+ * @returns {string} The normalized version.
+ */
 function normalizeVersion(version) {
   if (!version) {
     return FALLBACK_VERSION;


### PR DESCRIPTION
This update introduces item requirement tooltips to the tracker's check locations view. When players hover over a check location, they now see a popover (tooltip). It shows which items are needed to access that location, with already-collected items visually highlighted.

The tooltip system is powered by a new expression evaluation engine that reads the randomizer's logic rules and translates them into human-readable item requirements. The engine parses each location's access rules and evaluates them against the current randomizer settings. It produces a simplified list of what the player still needs. Boolean algebra simplification keeps the output concise.

The logic code is organized into three files. `expression-data.js` defines the data structures for representing requirements as sums (AND of OR clauses) and the simplification rules. `dnf-paths.js` handles converting between the internal CNF expression format and a DNF paths representation used during the region accessibility BFS. `expression-converter.js` ties everything together by walking the randomizer's region graph to determine which items are needed to reach each location from the starting point.

For the UI, a new `RequirementsTooltip` component renders the computed requirements inside a popover. The component separates the static requirement structure, which depends only on settings, from the dynamic ownership highlighting, which changes as the player tracks items. This ensures the expensive logic evaluation only runs once per location, not on every item change.

To ensure code quality and detect regressions, the PR also adds unit tests across three new test files. An ESLint JSDoc plugin was added, and all existing source files were annotated with proper JSDoc comments. Finally, a GitHub Actions CI workflow was added that builds the project, runs all tests, and checks linting on every push and pull request.

<img src="https://github.com/user-attachments/assets/86ab3107-2a4d-4af3-80bb-700ac9a64172" height="450">
<img src="https://github.com/user-attachments/assets/4d60fd6a-4281-4c5f-bbb2-8ff8ee93a582" height="450">