### PR TITLE
Add region check counts and update check opacity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hashfrog_tracker",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hashfrog_tracker",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",

--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -287,6 +287,20 @@ const LocationsList = ({
             style={style}
           >
             <span>{_.toUpper(HINT_REGIONS_SHORT_NAMES[regionName])}</span>
+            <span style={{
+              fontSize: "0.7em",
+              display: "block",
+              color: (numLocations - locationsCounter.checked) === 0
+                ? undefined
+                : locationsCounter.available === 0
+                  ? "#dc3545"
+                  : locationsCounter.available === (numLocations - locationsCounter.checked)
+                    ? "#198754"
+                    : "#ffc107",
+              opacity: (numLocations - locationsCounter.checked) === 0 ? 0.4 : 1,
+            }}>
+              {locationsCounter.available}/{numLocations - locationsCounter.checked}
+            </span>
           </button>
         </div>
       );

--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -143,8 +143,8 @@ const Buttons = ({ type, setType }) => {
 const HintRegion = ({ actions, items, locations, selectedRegion, setSelectedRegion }) => {
   const locationsList = _.map(locations[selectedRegion], (locationData, locationName) => {
     const style = {};
-    if (locationData.isChecked) { style.textDecoration = "line-through"; }
     if (!locationData.isAvailable) { style.opacity = "0.5"; }
+    if (locationData.isChecked) { style.textDecoration = "line-through"; style.opacity = "0.2"; }
 
     const displayName = Locations.removeRegionPrefix(locationName, selectedRegion);
 

--- a/src/scenes/Checks.js
+++ b/src/scenes/Checks.js
@@ -290,14 +290,14 @@ const LocationsList = ({
             <span style={{
               fontSize: "0.7em",
               display: "block",
-              color: (numLocations - locationsCounter.checked) === 0
+              color: locationsCounter.checked >= numLocations
                 ? undefined
                 : locationsCounter.available === 0
                   ? "#dc3545"
-                  : locationsCounter.available === (numLocations - locationsCounter.checked)
+                  : locationsCounter.available + locationsCounter.checked >= numLocations
                     ? "#198754"
                     : "#ffc107",
-              opacity: (numLocations - locationsCounter.checked) === 0 ? 0.4 : 1,
+              opacity: locationsCounter.checked >= numLocations ? 0.75 : 1,
             }}>
               {locationsCounter.available}/{numLocations - locationsCounter.checked}
             </span>


### PR DESCRIPTION
Update the region buttons to also show check count so it's easier to see at a glance how many checks are available in any given region. Color coded to match the existing left bar.

Also change the opacity of checked locations so that it's less prominent and help the remaining checks stand out.

<img width="282" height="446" alt="image" src="https://github.com/user-attachments/assets/3267a2b9-a434-4b4c-9daa-4702aec378f8" />
<img width="277" height="355" alt="image" src="https://github.com/user-attachments/assets/e68ce524-e9cf-44fb-9a60-74749b8cead2" />