### PR TITLE
Handle empty pots/crates

### DIFF
--- a/src/data/setting-strings.json
+++ b/src/data/setting-strings.json
@@ -1,7 +1,7 @@
 {
-  "currentActiveVersion": "9.0.0",
+  "currentActiveVersion": "9.1.0",
   "supportedVersions": [
-    "9.0.0",
+    "9.1.0",
     "8.3.0"
   ],
   "presets": [

--- a/src/utils/locations.js
+++ b/src/utils/locations.js
@@ -579,6 +579,9 @@ class Locations {
 
     // Pots
     else if (_.includes(["Pot", "FlyingPot"], location.type)) {
+      if (location.vanillaItem === "Nothing" && !SettingsHelper.getSetting("shuffle_empty_pots")) {
+        return false;
+      }
       const shufflePots = SettingsHelper.getSetting("shuffle_pots");
       if (shufflePots === "all") {
         return true;
@@ -593,6 +596,9 @@ class Locations {
 
     // Crates
     else if (_.includes(["Crate", "SmallCrate"], location.type)) {
+      if (location.vanillaItem === "Nothing" && !SettingsHelper.getSetting("shuffle_empty_crates")) {
+        return false;
+      }
       const shuffleCrates = SettingsHelper.getSetting("shuffle_crates");
       if (shuffleCrates === "all") {
         return true;


### PR DESCRIPTION
Previously, all pots and crates were shuffled regardless of the shuffle_empty_{pots|crates} settings. It now respects this setting.

Also updates current version to 9.1.0.