### PR TITLE
Layout tweaks

### DIFF
--- a/src/components/LayoutSelector.js
+++ b/src/components/LayoutSelector.js
@@ -1,4 +1,3 @@
-import FileSaver from "file-saver";
 import { useCallback, useState } from "react";
 
 import { Link } from "react-router-dom";
@@ -35,11 +34,6 @@ const LayoutSelector = () => {
     dispatch({ type: "LAYOUT_DEFAULT" });
     setKey(Math.random());
   }, [dispatch]);
-
-  const downloadCurrentLayout = useCallback(() => {
-    const jsonBlob = new Blob([JSON.stringify(layout)], { type: "text/plain" });
-    FileSaver.saveAs(jsonBlob, `${layout.layoutConfig.name.replace(/ /g, "_")}.json`);
-  }, [layout]);
 
   const applyPreset = useCallback(
     selected => {
@@ -83,7 +77,7 @@ const LayoutSelector = () => {
         <Link to="/editor" className="btn btn-light btn-sm w-25 me-2">
           Editor
         </Link>
-        <button type="button" className="btn btn-light btn-sm w-25 me-2" onClick={resetLayout}>
+        <button type="button" className="btn btn-light btn-sm w-25" onClick={resetLayout}>
           Reset
         </button>
       </div>
@@ -109,9 +103,6 @@ const LayoutSelector = () => {
           </button>
         </li>
       </ul>
-      <button type="button" className="btn btn-light btn-sm" onClick={downloadCurrentLayout}>
-        Download Current Layout
-      </button>
     </div>
   );
 };

--- a/src/components/LayoutSelector.js
+++ b/src/components/LayoutSelector.js
@@ -36,25 +36,33 @@ const LayoutSelector = () => {
     setKey(Math.random());
   }, [dispatch]);
 
-  const downloadLayout = selected => {
-    let selectedLayout = null;
-    switch (selected) {
-      case "hashfrog":
-        selectedLayout = hashfrogJSON;
-        break;
-      case "linso":
-        selectedLayout = linsoJSON;
-        break;
-      case "escapefromkak":
-        selectedLayout = escapefromkakJSON;
-        break;
-      default:
-        selectedLayout = hashfrogJSON;
-        break;
-    }
-    const jsonBlob = new Blob([JSON.stringify(selectedLayout)], { type: "text/plain" });
-    FileSaver.saveAs(jsonBlob, `${selectedLayout.layoutConfig.name.replace(/ /g, "_")}.json`);
-  };
+  const downloadCurrentLayout = useCallback(() => {
+    const jsonBlob = new Blob([JSON.stringify(layout)], { type: "text/plain" });
+    FileSaver.saveAs(jsonBlob, `${layout.layoutConfig.name.replace(/ /g, "_")}.json`);
+  }, [layout]);
+
+  const applyPreset = useCallback(
+    selected => {
+      let selectedLayout = null;
+      switch (selected) {
+        case "hashfrog":
+          selectedLayout = hashfrogJSON;
+          break;
+        case "linso":
+          selectedLayout = linsoJSON;
+          break;
+        case "escapefromkak":
+          selectedLayout = escapefromkakJSON;
+          break;
+        default:
+          selectedLayout = hashfrogJSON;
+          break;
+      }
+      dispatch({ type: "LAYOUT_UPDATE", payload: selectedLayout });
+      setKey(Math.random());
+    },
+    [dispatch],
+  );
 
   return (
     <div className="w-75">
@@ -75,7 +83,7 @@ const LayoutSelector = () => {
         <Link to="/editor" className="btn btn-light btn-sm w-25 me-2">
           Editor
         </Link>
-        <button type="button" className="btn btn-light btn-sm w-25" onClick={resetLayout}>
+        <button type="button" className="btn btn-light btn-sm w-25 me-2" onClick={resetLayout}>
           Reset
         </button>
       </div>
@@ -84,23 +92,26 @@ const LayoutSelector = () => {
       <h5>Layout Presets</h5>
       <ul className="list-unstyled list-horizontal">
         <li>
-          <button type="button" className="btn btn-link btm-sm p-0" onClick={() => downloadLayout("hashfrog")}>
+          <button type="button" className="btn btn-link btm-sm p-0" onClick={() => applyPreset("hashfrog")}>
             HashFrog
           </button>
         </li>
         <li className="list-divider">|</li>
         <li>
-          <button type="button" className="btn btn-link btm-sm p-0" onClick={() => downloadLayout("linso")}>
+          <button type="button" className="btn btn-link btm-sm p-0" onClick={() => applyPreset("linso")}>
             LinSo Like
           </button>
         </li>
         <li className="list-divider">|</li>
         <li>
-          <button type="button" className="btn btn-link btm-sm p-0" onClick={() => downloadLayout("escapefromkak")}>
+          <button type="button" className="btn btn-link btm-sm p-0" onClick={() => applyPreset("escapefromkak")}>
             EscapeFromKak
           </button>
         </li>
       </ul>
+      <button type="button" className="btn btn-light btn-sm" onClick={downloadCurrentLayout}>
+        Download Current Layout
+      </button>
     </div>
   );
 };

--- a/src/scenes/Editor/Editor.js
+++ b/src/scenes/Editor/Editor.js
@@ -1,5 +1,6 @@
 import FileSaver from "file-saver";
 import { useCallback, useMemo, useState } from "react";
+import { useLayout } from "../../context/layoutContext";
 import useDebounce from "../../hooks/useDebounce";
 import baseLayout from "../../layouts/base.json";
 import { generateId, readFileAsText } from "../../utils/utils";
@@ -115,8 +116,9 @@ function prepareLayout(rawLayout) {
 }
 
 const Editor = () => {
+  const { state: currentLayout } = useLayout();
   const [tab, setTab] = useState(0);
-  const [layout, setLayout] = useState({ ...baseLayout });
+  const [layout, setLayout] = useState(() => prepareLayout(currentLayout));
   const [layoutKey, setLayoutKey] = useState(Math.random());
 
   const newLayout = () => {


### PR DESCRIPTION
Various changes to the flow for selecting and editing layouts:
- Layout preset buttons now just change the active layout. Users can pick a built-in layout without having to download anything.
- Ability to download layouts from the main page is disabled.
- Opening the editor now loads the active layout instead of a blank one.