### PR TITLE
Add resume session button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hashfrog_tracker",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hashfrog_tracker",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hashfrog_tracker",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",

--- a/src/components/CustomReactSelect.js
+++ b/src/components/CustomReactSelect.js
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Select from "react-select";
+
+import { useHintEntry } from "../context/trackerContext";
 
 const CustomReactSelect = props => {
   const {
@@ -14,6 +16,10 @@ const CustomReactSelect = props => {
   const [value, setValue] = useState(null);
   const [inputValue, setInputValue] = useState("");
   const [hueRotate, setHueRotate] = useState(0);
+
+  const { setHintEntry, savedHintEntry } = useHintEntry(id);
+  const hintRestoredRef = useRef(false);
+  const isMountRef = useRef(true);
 
   const customStyles = useMemo(() => {
     return {
@@ -100,6 +106,25 @@ const CustomReactSelect = props => {
   useEffect(() => {
     onValueCallback(value);
   }, [onValueCallback, value]);
+
+  // Persist hint changes. Skip the initial mount so an empty input doesn't
+  // clobber a saved entry before the resume restore below can apply it.
+  useEffect(() => {
+    if (isMountRef.current) {
+      isMountRef.current = false;
+      return;
+    }
+    setHintEntry(value ? value.value : null);
+  }, [value, setHintEntry]);
+
+  // Restore a saved hint once, after a resumed session populates it.
+  useEffect(() => {
+    if (hintRestoredRef.current) { return; }
+    if (savedHintEntry !== null) {
+      setValue({ label: savedHintEntry, value: savedHintEntry });
+      hintRestoredRef.current = true;
+    }
+  }, [savedHintEntry]);
 
   return (
     <div onContextMenu={handleRightClick} onAuxClick={handleOnClick} style={{ flex: 1, overflow: "hidden" }}>

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { useElement, useItems, useLabelSelect } from "../context/trackerContext";
+import { useDraggedIcon, useElement, useIconCache, useItems, useLabelSelect } from "../context/trackerContext";
 
 // Base Icons
 import icon_check from "../assets/icons/check_16x16.png";
@@ -28,6 +28,7 @@ const Element = props => {
     icons = [],
     countConfig = [0, 5], // min, max
     receiver = false, // if draggin overrides item
+    persistIcon = false, // remember the displayed icon across sessions
     dragCurrent = false, // if dragging should default or drag the current selected
     selectedStartingIndex = 0, // on which of the icons we start
     items = [],
@@ -39,6 +40,8 @@ const Element = props => {
   } = useItems(items, id, name);
   useElement(id, startingItem);
   const labelSelect = useLabelSelect();
+  const { persistDraggedIcon, savedDraggedIcon } = useDraggedIcon(id);
+  const { iconUrlByName, iconNameByUrl } = useIconCache();
 
   const resolvedStartingIndex = savedIndex !== null ? savedIndex : trackerContextStartingIndex;
 
@@ -47,6 +50,7 @@ const Element = props => {
   const [iconHash, setIconHash] = useState(null);
   const [draggedIcon, setDraggedIcon] = useState(null);
   const hasUserInteracted = useRef(false);
+  const draggedIconRestoredRef = useRef(false);
 
   // Whenever a change in icon list is detected, reset the selection.
   // Only reset if icons actually changed AND we don't have a starting item.
@@ -80,6 +84,26 @@ const Element = props => {
     }
   }, [savedCounter]);
 
+  // Restore a receiver's saved icon once on resume. The saved value is a stable
+  // icon name, so resolve it to this session's url. If it's one of this
+  // element's own icons it was cycled to by clicking, so restore that index;
+  // otherwise it was dragged in from elsewhere, so show it as an override.
+  useEffect(() => {
+    if (draggedIconRestoredRef.current) { return; }
+    if (savedDraggedIcon === null) { return; }
+
+    const url = iconUrlByName[savedDraggedIcon];
+    if (!url) { return; } // icon cache not ready yet; wait for it to populate
+
+    const idx = icons.indexOf(url);
+    if (idx >= 0) {
+      setSelected(idx);
+    } else {
+      setDraggedIcon(url);
+    }
+    draggedIconRestoredRef.current = true;
+  }, [savedDraggedIcon, icons, iconUrlByName]);
+
   const icon = useMemo(() => {
     return icons[selected];
   }, [icons, selected]);
@@ -107,6 +131,7 @@ const Element = props => {
       if (!isCounter) {
         setDraggedIcon(null);
         setSelected(updated);
+        if (receiver || persistIcon) { persistDraggedIcon(iconNameByUrl[icons[updated]] ?? null); }
       } else {
         setCounter(updated);
       }
@@ -118,7 +143,7 @@ const Element = props => {
         markCounter(updated, name);
       }
     },
-    [id, icons, type, countConfig, selected, items, markCounter, markItem, counter, name],
+    [id, icons, type, countConfig, selected, items, markCounter, markItem, counter, name, receiver, persistIcon, persistDraggedIcon, iconNameByUrl],
   );
 
   const wheelHandler = useCallback(
@@ -155,9 +180,10 @@ const Element = props => {
         const { icon: droppedIcon } = JSON.parse(item);
         setDraggedIcon(droppedIcon);
         setSelected(0) //reset selected so if the dragged item gets cleared, the user will see the hashfrog
+        persistDraggedIcon(iconNameByUrl[droppedIcon] ?? null);
       }
     },
-    [receiver],
+    [receiver, persistDraggedIcon, iconNameByUrl],
   );
 
   return (
@@ -193,6 +219,7 @@ const Element = props => {
         )}
         {type === "nested" && (
           <Element
+            id={`${id}_nested`}
             name={`${name}_nested`}
             type="simple"
             icons={[icon_unknown, icon_check]}

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -34,11 +34,15 @@ const Element = props => {
     hidden = false
   } = props;
 
-  const { markCounter, markItem, startingIndex: trackerContextStartingIndex, startingItem } = useItems(items, id);
+  const {
+    markCounter, markItem, startingIndex: trackerContextStartingIndex, startingItem, savedIndex, savedCounter, savedLabelValue,
+  } = useItems(items, id, name);
   useElement(id, startingItem);
   const labelSelect = useLabelSelect();
 
-  const [selected, setSelected] = useState(trackerContextStartingIndex || selectedStartingIndex);
+  const resolvedStartingIndex = savedIndex !== null ? savedIndex : trackerContextStartingIndex;
+
+  const [selected, setSelected] = useState(resolvedStartingIndex || selectedStartingIndex);
   const [counter, setCounter] = useState(0);
   const [iconHash, setIconHash] = useState(null);
   const [draggedIcon, setDraggedIcon] = useState(null);
@@ -51,23 +55,30 @@ const Element = props => {
       return (acc += cv);
     }, "");
 
-    if (iconHash !== null && hash !== iconHash && trackerContextStartingIndex === 0) {
+    if (iconHash !== null && hash !== iconHash && resolvedStartingIndex === 0) {
       setSelected(0);
     }
 
     setIconHash(hash);
-  }, [icons, iconHash, name, trackerContextStartingIndex]);
+  }, [icons, iconHash, name, resolvedStartingIndex]);
 
-  // Sync selected state when starting items change
+  // Sync selected state when the restored/starting item index changes
   useEffect(() => {
-    if (trackerContextStartingIndex > 0) {
-      // This element should claim the starting item
-      setSelected(trackerContextStartingIndex);
+    if (resolvedStartingIndex > 0) {
+      // This element should claim the restored or starting item
+      setSelected(resolvedStartingIndex);
     } else if (!hasUserInteracted.current) {
       // Another element claimed the item and user hasn't interacted - reset to uncollected
       setSelected(0);
     }
-  }, [trackerContextStartingIndex]);
+  }, [resolvedStartingIndex]);
+
+  // Restore a saved counter value when one is present
+  useEffect(() => {
+    if (savedCounter !== null) {
+      setCounter(savedCounter);
+    }
+  }, [savedCounter]);
 
   const icon = useMemo(() => {
     return icons[selected];
@@ -176,6 +187,7 @@ const Element = props => {
             label={label}
             labelStartingIndex={labelStartingIndex}
             labelBackgroundColor={labelBackgroundColor}
+            savedValue={savedLabelValue}
             onLabelChange={(value) => labelSelect(id, name, value)}
           />
         )}
@@ -194,8 +206,16 @@ const Element = props => {
   );
 };
 
-const ElementLabel = ({ label, labelStartingIndex, labelBackgroundColor, onLabelChange }) => {
+const ElementLabel = ({ label, labelStartingIndex, labelBackgroundColor, savedValue, onLabelChange }) => {
   const [index, setIndex] = useState(labelStartingIndex);
+
+  // Restore a saved label selection by resolving its value back to an index
+  useEffect(() => {
+    if (savedValue !== null && Array.isArray(label)) {
+      const idx = label.indexOf(savedValue);
+      if (idx >= 0) { setIndex(idx); }
+    }
+  }, [savedValue, label]);
 
   const display = useMemo(() => {
     if (Array.isArray(label)) {

--- a/src/components/HintsTable.js
+++ b/src/components/HintsTable.js
@@ -36,6 +36,7 @@ const HintsTable = props => {
         hintRows.push(
           <td key={`${i}-${id}`} style={{ padding }}>
             <SometimesHint
+              id={`${id}-${i}`}
               labels={labels}
               width={width}
               color={color}
@@ -51,6 +52,7 @@ const HintsTable = props => {
         hintRows.push(
           <td key={`${i}-${id}`} style={{ padding }}>
             <LocationHint
+              id={`${id}-${i}`}
               labels={labels}
               width={width}
               color={color}

--- a/src/components/LocationHint.js
+++ b/src/components/LocationHint.js
@@ -51,6 +51,7 @@ const LocationHint = props => {
           icons={(bossElementsIcons.length && bossElementsIcons) || bossIcons}
           customStyle={{ marginRight: "0.25rem" }}
           receiver={bossReceiver}
+          persistIcon
         />
       )}
       <CustomReactSelect
@@ -73,8 +74,8 @@ const LocationHint = props => {
             receiver
           />
           <Element
-            id={`locations_item1_${id}`}
-            name={`locations_item1_${name}`}
+            id={`locations_item2_${id}`}
+            name={`locations_item2_${name}`}
             type="simple"
             size={[20, 20]}
             icons={itemsIcons}
@@ -82,8 +83,8 @@ const LocationHint = props => {
             receiver
           />
           <Element
-            id={`locations_item1_${id}`}
-            name={`locations_item1_${name}`}
+            id={`locations_item3_${id}`}
+            name={`locations_item3_${name}`}
             type="simple"
             size={[20, 20]}
             icons={itemsIcons}
@@ -91,8 +92,8 @@ const LocationHint = props => {
             receiver
           />
           <Element
-            id={`locations_item1_${id}`}
-            name={`locations_item1_${name}`}
+            id={`locations_item4_${id}`}
+            name={`locations_item4_${name}`}
             type="simple"
             size={[20, 20]}
             icons={itemsIcons}

--- a/src/components/SometimesHint.js
+++ b/src/components/SometimesHint.js
@@ -50,8 +50,8 @@ const SometimesHint = props => {
       )}
       {showIcon && dual && (
         <Element
-          id={`sometimes_item_${id}`}
-          name={`sometimes_item_${name}`}
+          id={`sometimes_item2_${id}`}
+          name={`sometimes_item2_${name}`}
           type="simple"
           size={[20, 20]}
           icons={icons}

--- a/src/context/trackerContext.js
+++ b/src/context/trackerContext.js
@@ -165,6 +165,7 @@ function buildSnapshot(state) {
     items_list: state.items_list,
     counters: state.counters,
     labelSelections: state.labelSelections,
+    hintEntries: state.hintEntries,
     starting_item_claims: state.starting_item_claims,
     unchanged_starting_inventory: state.unchanged_starting_inventory,
     checkedLocations,
@@ -474,6 +475,19 @@ function reducer(state, action) {
       saveSession(newState);
       return newState;
     }
+    case "HINT_ENTRY": {
+      const { id, value } = payload;
+      const newHintEntries = { ...state.hintEntries };
+      if (value) {
+        newHintEntries[id] = value;
+      } else {
+        delete newHintEntries[id];
+      }
+
+      const newState = { ...state, hintEntries: newHintEntries };
+      saveSession(newState);
+      return newState;
+    }
     case "ELEMENT_REGISTER": {
       const { id, startingItem } = payload;
 
@@ -518,6 +532,7 @@ function reducer(state, action) {
       const items_list = snapshot.items_list || {};
       const counters = snapshot.counters || {};
       const labelSelections = snapshot.labelSelections || {};
+      const hintEntries = snapshot.hintEntries || {};
       const starting_item_claims = snapshot.starting_item_claims || {};
       const unchanged_starting_inventory = snapshot.unchanged_starting_inventory || [];
 
@@ -567,6 +582,7 @@ function reducer(state, action) {
         items_list,
         counters,
         labelSelections,
+        hintEntries,
         starting_item_claims,
         unchanged_starting_inventory,
       };
@@ -594,6 +610,7 @@ function TrackerProvider(props) {
     settings_string: getSettingsStringCache(),
     generator_version: getGeneratorVersionCache(),
     labelSelections: {}, // { elementId: { name, value } } - e.g. { 1: {"efk_dungeon", "DEK"} }
+    hintEntries: {}, // { selectId: "hint string" } - text typed into hint inputs
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -733,6 +750,22 @@ const useLabelSelect = () => {
   );
 };
 
+const useHintEntry = (id = null) => {
+  const { state, dispatch } = useTracker();
+
+  const setHintEntry = useCallback(
+    value => dispatch({ type: "HINT_ENTRY", payload: { id, value } }),
+    [dispatch, id],
+  );
+
+  const savedHintEntry = useMemo(() => {
+    if (id === null) { return null; }
+    return state.hintEntries[id] ?? null;
+  }, [id, state.hintEntries]);
+
+  return { setHintEntry, savedHintEntry };
+};
+
 const useSelectedEFKDungeons = () => {
   const { state: { labelSelections } } = useTracker();
   return useMemo(() => getSelectedEFKDungeons(labelSelections), [labelSelections]);
@@ -780,7 +813,7 @@ const useSessionRestore = isReady => {
 
 export {
   getGeneratorVersionCache, getSettingsStringCache, loadSession, TrackerProvider,
-  useChecks, useElement, useItems, useLabelSelect, useLocation,
+  useChecks, useElement, useHintEntry, useItems, useLabelSelect, useLocation,
   useSelectedEFKDungeons, useSessionRestore, useSettingsString, useTracker
 };
 

--- a/src/context/trackerContext.js
+++ b/src/context/trackerContext.js
@@ -166,6 +166,7 @@ function buildSnapshot(state) {
     counters: state.counters,
     labelSelections: state.labelSelections,
     hintEntries: state.hintEntries,
+    draggedIcons: state.draggedIcons,
     starting_item_claims: state.starting_item_claims,
     unchanged_starting_inventory: state.unchanged_starting_inventory,
     checkedLocations,
@@ -488,6 +489,23 @@ function reducer(state, action) {
       saveSession(newState);
       return newState;
     }
+    case "DRAGGED_ICON_SET": {
+      const { id, iconName } = payload;
+      const newDraggedIcons = { ...state.draggedIcons };
+      if (iconName) {
+        newDraggedIcons[id] = iconName;
+      } else {
+        delete newDraggedIcons[id];
+      }
+
+      const newState = { ...state, draggedIcons: newDraggedIcons };
+      saveSession(newState);
+      return newState;
+    }
+    case "ICON_CACHE_SET": {
+      const { iconUrlByName, iconNameByUrl } = payload;
+      return { ...state, iconUrlByName, iconNameByUrl };
+    }
     case "ELEMENT_REGISTER": {
       const { id, startingItem } = payload;
 
@@ -533,6 +551,7 @@ function reducer(state, action) {
       const counters = snapshot.counters || {};
       const labelSelections = snapshot.labelSelections || {};
       const hintEntries = snapshot.hintEntries || {};
+      const draggedIcons = snapshot.draggedIcons || {};
       const starting_item_claims = snapshot.starting_item_claims || {};
       const unchanged_starting_inventory = snapshot.unchanged_starting_inventory || [];
 
@@ -583,6 +602,7 @@ function reducer(state, action) {
         counters,
         labelSelections,
         hintEntries,
+        draggedIcons,
         starting_item_claims,
         unchanged_starting_inventory,
       };
@@ -611,6 +631,9 @@ function TrackerProvider(props) {
     generator_version: getGeneratorVersionCache(),
     labelSelections: {}, // { elementId: { name, value } } - e.g. { 1: {"efk_dungeon", "DEK"} }
     hintEntries: {}, // { selectId: "hint string" } - text typed into hint inputs
+    draggedIcons: {}, // { elementId: iconName } - stable name of the icon shown on a receiver
+    iconUrlByName: {}, // { iconName: blobUrl } - this session's icon cache (name -> url)
+    iconNameByUrl: {}, // { blobUrl: iconName } - reverse of iconUrlByName (url -> name)
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -766,6 +789,34 @@ const useHintEntry = (id = null) => {
   return { setHintEntry, savedHintEntry };
 };
 
+const useDraggedIcon = (id = null) => {
+  const { state, dispatch } = useTracker();
+
+  const persistDraggedIcon = useCallback(
+    iconName => dispatch({ type: "DRAGGED_ICON_SET", payload: { id, iconName } }),
+    [dispatch, id],
+  );
+
+  const savedDraggedIcon = useMemo(() => {
+    if (id === null) { return null; }
+    return state.draggedIcons[id] ?? null;
+  }, [id, state.draggedIcons]);
+
+  return { persistDraggedIcon, savedDraggedIcon };
+};
+
+const useIconCache = () => {
+  const { state, dispatch } = useTracker();
+
+  const setIconCache = useCallback(
+    (iconUrlByName, iconNameByUrl) =>
+      dispatch({ type: "ICON_CACHE_SET", payload: { iconUrlByName, iconNameByUrl } }),
+    [dispatch],
+  );
+
+  return { setIconCache, iconUrlByName: state.iconUrlByName, iconNameByUrl: state.iconNameByUrl };
+};
+
 const useSelectedEFKDungeons = () => {
   const { state: { labelSelections } } = useTracker();
   return useMemo(() => getSelectedEFKDungeons(labelSelections), [labelSelections]);
@@ -813,7 +864,7 @@ const useSessionRestore = isReady => {
 
 export {
   getGeneratorVersionCache, getSettingsStringCache, loadSession, TrackerProvider,
-  useChecks, useElement, useHintEntry, useItems, useLabelSelect, useLocation,
+  useChecks, useDraggedIcon, useElement, useHintEntry, useIconCache, useItems, useLabelSelect, useLocation,
   useSelectedEFKDungeons, useSessionRestore, useSettingsString, useTracker
 };
 

--- a/src/context/trackerContext.js
+++ b/src/context/trackerContext.js
@@ -1,9 +1,10 @@
 import _ from "lodash";
-import { createContext, useCallback, useContext, useEffect, useMemo, useReducer } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef } from "react";
 
 import COMBO_ITEMS from "../data/combo-items.json";
 import COUNTER_TO_ITEM from "../data/counter-to-item.json";
 import DEFAULT_ITEMS from "../data/default-items.json";
+import DUNGEONS from "../data/dungeons.json";
 import ITEMS_JSON from "../data/items.json";
 import UUID_TO_ITEM from "../data/uuid-to-item.json";
 import { getEFKSkipRegions, getSelectedEFKDungeons, isEFK, isEFKLabel } from "../utils/efk";
@@ -134,6 +135,71 @@ function setGeneratorVersionCache(version) {
   localStorage.setItem("generator_version", version);
 }
 
+// localStorage key for a persisted tracker session (single slot).
+const SESSION_KEY = "tracker_session";
+
+/**
+ * Builds a serializable snapshot of user progress from the tracker state.
+ * @param {object} state - The current tracker state.
+ * @returns {object} A snapshot suitable for JSON serialization.
+ */
+function buildSnapshot(state) {
+  const checkedLocations = {};
+  _.forEach(state.locations, (locations, regionName) => {
+    const checkedNames = _.keys(_.pickBy(locations, location => location.isChecked));
+    if (checkedNames.length) {
+      checkedLocations[regionName] = checkedNames;
+    }
+  });
+
+  return {
+    // Whether this was a check-tracking session, so Resume opens the right route/size.
+    checksEnabled: !_.isEmpty(state.locations),
+    // The layout active at save time, used to detect layout changes before resuming.
+    layout: localStorage.getItem("layout"),
+    // MQ/shortcut toggles live in the settings singletons, not in reducer state.
+    mq_dungeons_specific: SettingsHelper.settings?.mq_dungeons_specific || [],
+    dungeon_shortcuts: SettingsHelper.settings?.dungeon_shortcuts || [],
+    settings_string: state.settings_string,
+    generator_version: state.generator_version,
+    items_list: state.items_list,
+    counters: state.counters,
+    labelSelections: state.labelSelections,
+    starting_item_claims: state.starting_item_claims,
+    unchanged_starting_inventory: state.unchanged_starting_inventory,
+    checkedLocations,
+  };
+}
+
+/**
+ * Persists a snapshot of the tracker state to localStorage.
+ * @param {object} state - The current tracker state.
+ */
+function saveSession(state) {
+  try {
+    localStorage.setItem(SESSION_KEY, JSON.stringify(buildSnapshot(state)));
+  } catch (err) {
+    console.warn("Failed to save tracker session:", err);
+  }
+}
+
+/**
+ * Loads the persisted session snapshot, if one exists and is parseable.
+ * @returns {object|null} The snapshot, or null when absent/corrupt.
+ */
+function loadSession() {
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) { return null; }
+    const snapshot = JSON.parse(raw);
+    if (!snapshot || typeof snapshot !== "object") { return null; }
+    return snapshot;
+  } catch (err) {
+    console.warn("Failed to load tracker session:", err);
+    return null;
+  }
+}
+
 /**
  * Tracker context reducer handling all state mutations.
  * @param {object} state - The current tracker state.
@@ -178,10 +244,12 @@ function reducer(state, action) {
         const isChecked = locations[regionName][locationName].isChecked;
         _.set(locations, [regionName, locationName, "isChecked"], !isChecked);
 
-        return {
+        const newState = {
           ...state,
           locations,
         };
+        saveSession(newState);
+        return newState;
       }
     }
     case "MQ_TOGGLE": {
@@ -218,10 +286,12 @@ function reducer(state, action) {
         parseItems(state.items_list, state.counters, state.unchanged_starting_inventory),
       );
 
-      return {
+      const newState = {
         ...state,
         locations: validatedLocations,
       };
+      saveSession(newState);
+      return newState;
     }
     case "SHORTCUT_TOGGLE": {
       // payload = regionName
@@ -244,10 +314,12 @@ function reducer(state, action) {
         parseItems(state.items_list, state.counters, state.unchanged_starting_inventory),
       );
 
-      return {
+      const newState = {
         ...state,
         locations: validatedLocations,
       };
+      saveSession(newState);
+      return newState;
     }
     case "REGION_TOGGLE": {
       // payload = regionName
@@ -260,10 +332,12 @@ function reducer(state, action) {
         _.set(locationData, "isChecked", !setTo);
       });
 
-      return {
+      const newState = {
         ...state,
         locations,
       };
+      saveSession(newState);
+      return newState;
     }
     case "ITEMS_UPDATE_FROM_LOGIC": {
       const settings = payload;
@@ -332,12 +406,14 @@ function reducer(state, action) {
         ? state.locations
         : validateLocations(state.locations, parsedItems, getEFKSkipRegions(state.settings_string, state.labelSelections));
 
-      return {
+      const newState = {
         ...state,
         locations,
         items: parsedItems,
         counters,
       };
+      saveSession(newState);
+      return newState;
     }
     case "ITEM_MARK": {
       const { item, parentID } = payload;
@@ -357,12 +433,14 @@ function reducer(state, action) {
         ? state.locations
         : validateLocations(state.locations, parsedItems, getEFKSkipRegions(state.settings_string, state.labelSelections));
 
-      return {
+      const newState = {
         ...state,
         locations,
         items: parsedItems,
         items_list,
       };
+      saveSession(newState);
+      return newState;
     }
     case "STRING_SET": {
       setSettingsStringCache(payload);
@@ -382,6 +460,7 @@ function reducer(state, action) {
       const { elementId, name, value } = payload;
       const newLabelSelections = { ...state.labelSelections, [elementId]: { name, value } };
 
+      let newState = { ...state, labelSelections: newLabelSelections };
       if (isEFKLabel(name) && isEFK(state.settings_string)) {
         // Accessible dungeons changed; revalidate locations against the updated skip regions.
         const locations = validateLocations(
@@ -389,10 +468,11 @@ function reducer(state, action) {
           state.items,
           getEFKSkipRegions(state.settings_string, newLabelSelections),
         );
-        return { ...state, labelSelections: newLabelSelections, locations };
+        newState = { ...newState, locations };
       }
 
-      return { ...state, labelSelections: newLabelSelections };
+      saveSession(newState);
+      return newState;
     }
     case "ELEMENT_REGISTER": {
       const { id, startingItem } = payload;
@@ -407,7 +487,7 @@ function reducer(state, action) {
       let newUnchangedStartingInventory = [...state.unchanged_starting_inventory];
       const newStartingItemClaims = { ...state.starting_item_claims };
 
-      if (startingItem !== null) {
+      if (startingItem !== null && newItemsList[id] === undefined) {
         newItemsList[id] = startingItem;
 
         // Note that starting item appears on the tracker layout
@@ -429,6 +509,66 @@ function reducer(state, action) {
         items_list: newItemsList,
         unchanged_starting_inventory: newUnchangedStartingInventory,
         starting_item_claims: newStartingItemClaims,
+      };
+    }
+    case "SESSION_RESTORE": {
+      const snapshot = payload;
+      if (!snapshot) { return state; }
+
+      const items_list = snapshot.items_list || {};
+      const counters = snapshot.counters || {};
+      const labelSelections = snapshot.labelSelections || {};
+      const starting_item_claims = snapshot.starting_item_claims || {};
+      const unchanged_starting_inventory = snapshot.unchanged_starting_inventory || [];
+
+      if (snapshot.mq_dungeons_specific) {
+        _.set(LogicHelper.settings, "mq_dungeons_specific", snapshot.mq_dungeons_specific);
+        SettingsHelper.settings["mq_dungeons_specific"] = snapshot.mq_dungeons_specific;
+      }
+      if (snapshot.dungeon_shortcuts) {
+        _.set(LogicHelper.settings, "dungeon_shortcuts", snapshot.dungeon_shortcuts);
+        SettingsHelper.settings["dungeon_shortcuts"] = snapshot.dungeon_shortcuts;
+      }
+      SettingsHelper.invalidateCachedSets();
+
+      const locations = _.cloneDeep(state.locations);
+
+      // Rebuild each dungeon's location list to match the restored MQ setting.
+      _.forEach(_.keys(locations), regionName => {
+        if (!_.includes(DUNGEONS, regionName)) { return; }
+        const locationKey = SettingsHelper.isMQDungeon(regionName) ? "dungeon_mq" : "dungeon";
+        _.set(locations, regionName, {});
+        _.forEach(Locations.locations[locationKey][regionName], (locationData, locationName) => {
+          if (Locations.isProgressLocation(locationData)) {
+            _.set(locations, [regionName, locationName], { isAvailable: false, isChecked: false });
+          }
+        });
+      });
+
+      _.forEach(snapshot.checkedLocations || {}, (locationNames, regionName) => {
+        if (!locations[regionName]) { return; }
+        locationNames.forEach(locationName => {
+          if (locations[regionName][locationName]) {
+            _.set(locations, [regionName, locationName, "isChecked"], true);
+          }
+        });
+      });
+
+      const settingsString = snapshot.settings_string || state.settings_string;
+      const skipRegions = isEFK(settingsString) ? getEFKSkipRegions(settingsString, labelSelections) : new Set();
+
+      const parsedItems = parseItems(items_list, counters, unchanged_starting_inventory);
+      const validatedLocations = validateLocations(locations, parsedItems, skipRegions);
+
+      return {
+        ...state,
+        locations: validatedLocations,
+        items: parsedItems,
+        items_list,
+        counters,
+        labelSelections,
+        starting_item_claims,
+        unchanged_starting_inventory,
       };
     }
     default:
@@ -458,7 +598,6 @@ function TrackerProvider(props) {
 
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  // Implementar local storage?
   return <TrackerContext.Provider value={{ state, dispatch }} {...props} />;
 }
 
@@ -507,7 +646,7 @@ const useLocation = () => {
   return [actions];
 };
 
-const useItems = (items, elementId = null) => {
+const useItems = (items, elementId = null, name = null) => {
   const { state, dispatch } = useTracker();
 
   const actions = useMemo(
@@ -562,7 +701,27 @@ const useItems = (items, elementId = null) => {
     return itemID;
   }, [items, state.unchanged_starting_inventory, state.starting_item_claims, elementId]);
 
-  return { ...actions, startingIndex, startingItem };
+  const savedIndex = useMemo(() => {
+    if (elementId === null || !items || !items.length) { return null; }
+    const savedItem = state.items_list[elementId];
+    if (!savedItem) { return null; }
+    const idx = items.indexOf(savedItem);
+    return idx >= 0 ? idx : null;
+  }, [items, elementId, state.items_list]);
+
+  const savedCounter = useMemo(() => {
+    if (name === null) { return null; }
+    const value = state.counters[name];
+    return value === undefined ? null : value;
+  }, [name, state.counters]);
+
+  const savedLabelValue = useMemo(() => {
+    if (elementId === null) { return null; }
+    const selection = state.labelSelections[elementId];
+    return selection ? selection.value : null;
+  }, [elementId, state.labelSelections]);
+
+  return { ...actions, startingIndex, startingItem, savedIndex, savedCounter, savedLabelValue };
 };
 
 const useLabelSelect = () => {
@@ -596,9 +755,32 @@ const useSettingsString = () => {
   return { ...actions, settings_string, generator_version };
 };
 
+/**
+ * Restores a saved session once the tracker structure is ready, when the
+ * window was opened with `?resume=1`. Runs at most once.
+ * @param {boolean} isReady - True when locations/items have finished building.
+ */
+const useSessionRestore = isReady => {
+  const { dispatch } = useTracker();
+  const restoredRef = useRef(false);
+
+  useEffect(() => {
+    if (!isReady || restoredRef.current) { return; }
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("resume") !== "1") { return; }
+
+    const snapshot = loadSession();
+    if (snapshot) {
+      dispatch({ type: "SESSION_RESTORE", payload: snapshot });
+    }
+    restoredRef.current = true;
+  }, [isReady, dispatch]);
+};
+
 export {
-  getGeneratorVersionCache, getSettingsStringCache, TrackerProvider, useChecks,
-  useElement, useItems, useLabelSelect, useLocation, useSelectedEFKDungeons,
-  useSettingsString, useTracker
+  getGeneratorVersionCache, getSettingsStringCache, loadSession, TrackerProvider,
+  useChecks, useElement, useItems, useLabelSelect, useLocation,
+  useSelectedEFKDungeons, useSessionRestore, useSettingsString, useTracker
 };
 

--- a/src/scenes/Layout.js
+++ b/src/scenes/Layout.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useLayout } from "../context/layoutContext";
+import { useIconCache } from "../context/trackerContext";
 
 // Components
 import Element from "../components/Element";
@@ -20,6 +21,7 @@ const baseURL = process.env.PUBLIC_URL;
 
 const Layout = props => {
   const { state: layoutContext } = useLayout();
+  const { setIconCache } = useIconCache();
 
   const renderLayout = useMemo(() => {
     if (props.layout) { return props.layout; }
@@ -62,14 +64,17 @@ const Layout = props => {
           }));
       }),
     );
-    icons = icons.reduce((accumulator, image) => {
-      accumulator[image.icon] = image.image;
-      return accumulator;
-    }, {});
+    const iconUrlByName = {};
+    const iconNameByUrl = {};
+    icons.forEach(({ icon, image }) => {
+      iconUrlByName[icon] = image; // name -> url
+      iconNameByUrl[image] = icon; // url -> name
+    });
 
-    setCachedIcons(icons);
-    return icons;
-  }, [elements]);
+    setCachedIcons(iconUrlByName);
+    setIconCache(iconUrlByName, iconNameByUrl);
+    return iconUrlByName;
+  }, [elements, setIconCache]);
 
   const getCacheElement = useCallback(
     id => {

--- a/src/scenes/TrackerChecks.js
+++ b/src/scenes/TrackerChecks.js
@@ -1,10 +1,18 @@
+import _ from "lodash";
+
 import frog from "../assets/icons/hashfrogsping.gif";
+import { useSessionRestore, useTracker } from "../context/trackerContext";
 import useLogicInitialization from "../hooks/useLogicInitialization";
 import Checks from "./Checks";
 import Layout from "./Layout";
 
 const TrackerChecks = () => {
   const { isLoading } = useLogicInitialization();
+  const { state } = useTracker();
+
+  // In checks mode the location structure is built by Checks.js after logic
+  // loads; only then is it safe to overlay saved progress.
+  useSessionRestore(!isLoading && !_.isEmpty(state.locations));
 
   if (isLoading) {
     return (

--- a/src/scenes/TrackerLauncher.js
+++ b/src/scenes/TrackerLauncher.js
@@ -9,7 +9,7 @@ import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import LayoutSelector from "../components/LayoutSelector";
 import { useLayout } from "../context/layoutContext";
-import { useSettingsString } from "../context/trackerContext";
+import { loadSession, useSettingsString } from "../context/trackerContext";
 import SettingStringsJSON from "../data/setting-strings.json";
 import useDebounce from "../hooks/useDebounce";
 
@@ -42,19 +42,6 @@ const TrackerLauncher = () => {
       height: height + heightPadding,
     };
   }, [checks, layout]);
-
-  const launchTracker = useCallback(() => {
-    let url = `${baseURL}/tracker`;
-    if (checks) { url = `${baseURL}/tracker/checks`; }
-
-    const { width, height } = layoutSize;
-
-    window.open(
-      url,
-      "HashFrog Tracker",
-      `toolbar=0,location=0,status=0,menubar=0,scrollbars=0,resizable=0,width=${width},height=${height}`
-    );
-  }, [checks, layoutSize]);
 
   const {
     setString: setSettingsStringCache,
@@ -94,6 +81,62 @@ const TrackerLauncher = () => {
     setGeneratorVersionCache(debouncedVersion);
   }, [debouncedVersion, setGeneratorVersionCache]);
 
+  const launchTracker = useCallback(() => {
+    let url = `${baseURL}/tracker`;
+    if (checks) { url = `${baseURL}/tracker/checks`; }
+
+    // Launch with exactly what the launcher currently displays, in case a
+    // prior resumeSession overwrote the cached config in localStorage.
+    localStorage.setItem("layout", JSON.stringify(layout));
+    localStorage.setItem("settings_string", checks ? settingsString : "");
+    localStorage.setItem("generator_version", generatorVersion);
+
+    const { width, height } = layoutSize;
+
+    window.open(
+      url,
+      "HashFrog Tracker",
+      `toolbar=0,location=0,status=0,menubar=0,scrollbars=0,resizable=0,width=${width},height=${height}`
+    );
+  }, [checks, layout, settingsString, generatorVersion, layoutSize]);
+
+  // Track whether a saved session exists so the Resume button reacts when one
+  // is created in a popup window; refresh on focus when returning to the launcher.
+  const [savedSession, setSavedSession] = useState(loadSession);
+  useEffect(() => {
+    const refresh = () => setSavedSession(loadSession());
+    window.addEventListener("focus", refresh);
+    return () => window.removeEventListener("focus", refresh);
+  }, []);
+
+  const resumeSession = useCallback(() => {
+    // Re-read fresh: another window may have saved a newer session since the
+    // launcher last rendered, leaving the render-time `savedSession` stale.
+    const session = loadSession();
+    if (!session) { return; }
+
+    // Force the resumed window to reproduce the saved session's config.
+    localStorage.setItem("layout", session.layout);
+    localStorage.setItem("settings_string", session.settings_string);
+    localStorage.setItem("generator_version", session.generator_version);
+
+    const resumeChecks = !!session.checksEnabled;
+    let url = resumeChecks ? `${baseURL}/tracker/checks` : `${baseURL}/tracker`;
+    url += "?resume=1";
+
+    const {
+      layoutConfig: { width, height },
+    } = JSON.parse(session.layout);
+    const windowWidth = width + (resumeChecks ? 285 : 0);
+    const windowHeight = height + 25;
+
+    window.open(
+      url,
+      "HashFrog Tracker",
+      `toolbar=0,location=0,status=0,menubar=0,scrollbars=0,resizable=0,width=${windowWidth},height=${windowHeight}`
+    );
+  }, []);
+
   const updateString = (preset) => {
 
     if (preset.settingsString) {
@@ -132,7 +175,7 @@ const TrackerLauncher = () => {
             Tracker Settings
           </h5>
 
-          <div className="d-grid mb-4">
+          <div className="d-grid mb-3">
             <Button
               type="button"
               variant="success"
@@ -140,7 +183,18 @@ const TrackerLauncher = () => {
               onClick={launchTracker}
               className="fw-semibold"
             >
-              🚀 Launch Tracker
+              🚀 Launch New Tracker
+            </Button>
+          </div>
+
+          <div className="d-grid mb-4">
+            <Button
+              type="button"
+              variant="outline-light"
+              onClick={resumeSession}
+              disabled={!savedSession}
+            >
+              ↻ Resume Session
             </Button>
           </div>
 

--- a/src/scenes/TrackerLayout.js
+++ b/src/scenes/TrackerLayout.js
@@ -1,9 +1,11 @@
 import frog from "../assets/icons/hashfrogsping.gif";
+import { useSessionRestore } from "../context/trackerContext";
 import useLogicInitialization from "../hooks/useLogicInitialization";
 import Layout from "./Layout";
 
 const TrackerLayout = () => {
-  const { isLoading } = useLogicInitialization();
+  const { isLoading, isInitialized } = useLogicInitialization();
+  useSessionRestore(isInitialized);
 
   if (isLoading) {
     return (

--- a/src/scenes/Welcome.js
+++ b/src/scenes/Welcome.js
@@ -67,7 +67,11 @@ const Welcome = () => {
               <Accordion.Body className="bg-dark text-light">
                 <ul className="list-unstyled mb-0">
                   <li className="mb-2">
-                    <Badge bg="success" className="me-2">0.7.1</Badge>
+                    <Badge bg="success" className="me-2">0.7.2</Badge>
+                    <span className="small">Identical checks grouping, EfK preset, resume session button.</span>
+                  </li>
+                  <li className="mb-2">
+                    <Badge bg="secondary" className="me-2">0.7.1</Badge>
                     <span className="small">Add item requirement tooltips on check locations, showing what items are needed with tracked items highlighted.</span>
                   </li>
                   <li className="mb-2">


### PR DESCRIPTION
Adds a resume session button to the launcher. This allows users to close their tracker, and then pick up where they left off later. This includes items, dungeon rewards, reward labels, songs, keys, and completed checks. If random dungeon shortcuts or random MQ dungeons are turned on, it will also remember which dungeons were toggled as having shortcuts or MQ.

A new HINT_ENTRY reducer case is added to save text typed into hint boxes, including paths, barrens, and sometimes.

Dragged icons required a bit more work to support. On opening the launcher, icons are mapped to blob URLs, and these are not consistent whenever the launcher is opened. We already map icon name -> URL, so we create the inverse URL -> name map, and expose both to the tracker context. When icons are dragged, we save the names, and when resuming a session, we translate the names back to the current session's blob URLs.

The boss boxes in path hints use the same flow as clicking the receivers, but they aren't tagged as receivers, so they're given a new persistIcon property so we know to save those icons.

Resuming a session will force the current layout, generator version, and settings string back to the saved ones.

<img width="680" height="440" alt="image" src="https://github.com/user-attachments/assets/e21e63f3-424b-4a9b-b322-7ef32d0638e1" />
